### PR TITLE
PST-12 Implement session-based Gemara reservation and cancellation logic

### DIFF
--- a/ChainApp/templates/ChainApp/session_detail.html
+++ b/ChainApp/templates/ChainApp/session_detail.html
@@ -23,8 +23,11 @@
                     <div class="col-md-4">
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" id="gemarot_{{ item.gemara.pk }}" name="gemarot" value="{{ item.gemara.pk }}"
-                            {% if item.reserved %}
+                            {% if item.reserved_by_user %}
                                 checked
+                            {% endif %}
+                            {% if item.reserved and not item.reserved_by_user %}
+                                disabled
                             {% endif %}>
                             <label class="form-check-label" for="gemarot_{{ item.gemara.pk }}">
                                 {{ item.gemara.name }}


### PR DESCRIPTION
Cette PR introduit des fonctionnalités essentielles pour la gestion des réservations et annulations de Gemara dans le cadre de sessions. Elle permet aux utilisateurs de réserver des Gemarot spécifiques au sein d'une session et d'annuler leurs réservations si nécessaire.

Modifications apportées :
Vue SessionDetailView :

Gestion des réservations :

Les utilisateurs connectés peuvent désormais voir les Gemarot qu'ils ont réservés dans une session.
Les cases à cocher permettent de sélectionner ou de désélectionner les Gemarot disponibles, avec un état désactivé pour celles déjà réservées par d'autres utilisateurs.
L'annulation de la réservation est possible en décochant les Gemarot réservées et en soumettant le formulaire.
Vérification de l'association Person :

Une vérification a été ajoutée pour s'assurer que chaque utilisateur a bien un objet Person associé. Si un utilisateur n'a pas d'objet Person, la vue redirige vers une page appropriée (à implémenter) pour créer cet objet.
Gestion des cas où aucun Person n'est associé à l'utilisateur, empêchant ainsi les erreurs RelatedObjectDoesNotExist.