### PR TITLE
fix(seo): SITE_URL → petite-jerusalem.fr (corrige les pages de partage cassées)

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -24,7 +24,7 @@ const db = getFirestore();
 // Cap concurrency to keep costs bounded; previews are tiny and cached.
 setGlobalOptions({ maxInstances: 3 });
 
-const SITE_URL = "https://petite-jerusalem.web.app";
+const SITE_URL = "https://petite-jerusalem.fr";
 const OG_IMAGE = `${SITE_URL}/og-image.jpg`;
 const CHIOURIM_WEBHOOK =
   "https://n8n.phenixel.fr/webhook/1e7e1be1-1f2c-4916-a6f6-34ff8f437ef6";

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     />
     <meta name="author" content="Petite Jérusalem" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://petite-jerusalem.web.app/" />
+    <link rel="canonical" href="https://petite-jerusalem.fr/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
@@ -27,8 +27,8 @@
       property="og:description"
       content="Créez et rejoignez des sessions de partage de lectures et d'études de Torah. Réservez des textes, étudiez à plusieurs et suivez votre progression."
     />
-    <meta property="og:url" content="https://petite-jerusalem.web.app/" />
-    <meta property="og:image" content="https://petite-jerusalem.web.app/og-image.jpg" />
+    <meta property="og:url" content="https://petite-jerusalem.fr/" />
+    <meta property="og:image" content="https://petite-jerusalem.fr/og-image.jpg" />
     <meta property="og:image:width" content="1024" />
     <meta property="og:image:height" content="1024" />
     <meta property="og:image:alt" content="Petite Jérusalem — partage de lectures et d'études de Torah" />
@@ -40,7 +40,7 @@
       name="twitter:description"
       content="Créez et rejoignez des sessions de partage de lectures et d'études de Torah. Réservez des textes et étudiez avec la communauté."
     />
-    <meta name="twitter:image" content="https://petite-jerusalem.web.app/og-image.jpg" />
+    <meta name="twitter:image" content="https://petite-jerusalem.fr/og-image.jpg" />
 
     <meta name="theme-color" content="#0f172a" />
 
@@ -51,7 +51,7 @@
         "@type": "WebSite",
         "name": "Petite Jérusalem",
         "alternateName": "Petite Jerusalem",
-        "url": "https://petite-jerusalem.web.app/",
+        "url": "https://petite-jerusalem.fr/",
         "description": "Partage de lectures et d'études de Torah : créez des sessions, réservez des textes et étudiez à plusieurs.",
         "inLanguage": "fr-FR"
       }
@@ -61,8 +61,8 @@
         "@context": "https://schema.org",
         "@type": "Organization",
         "name": "Petite Jérusalem",
-        "url": "https://petite-jerusalem.web.app/",
-        "logo": "https://petite-jerusalem.web.app/og-image.jpg"
+        "url": "https://petite-jerusalem.fr/",
+        "logo": "https://petite-jerusalem.fr/og-image.jpg"
       }
     </script>
 

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -24,7 +24,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export const SITE_URL = "https://petite-jerusalem.web.app";
+export const SITE_URL = "https://petite-jerusalem.fr";
 
 /**
  * Public, statically-known routes that benefit from their own social preview.

--- a/src/__tests__/prerenderSeo.test.ts
+++ b/src/__tests__/prerenderSeo.test.ts
@@ -7,11 +7,11 @@ const template = `<!doctype html>
   <head>
     <title>Petite Jérusalem | Base</title>
     <meta name="description" content="Description de base" />
-    <link rel="canonical" href="https://petite-jerusalem.web.app/" />
+    <link rel="canonical" href="https://petite-jerusalem.fr/" />
     <meta property="og:title" content="OG base" />
     <meta property="og:description" content="OG desc base" />
-    <meta property="og:url" content="https://petite-jerusalem.web.app/" />
-    <meta property="og:image" content="https://petite-jerusalem.web.app/og-image.jpg" />
+    <meta property="og:url" content="https://petite-jerusalem.fr/" />
+    <meta property="og:image" content="https://petite-jerusalem.fr/og-image.jpg" />
     <meta name="twitter:title" content="TW base" />
     <meta name="twitter:description" content="TW desc base" />
     <meta name="robots" content="index, follow" />


### PR DESCRIPTION
## Problème
`SITE_URL = https://petite-jerusalem.web.app` (dans la function ET le prerender) pointe vers un site qui n'existe pas (« Site Not Found »). Une fois les rewrites hosting actifs, **toutes les pages de détail** `/share-reading/session/**` et `/chiourim/**` servaient la page d'erreur Firebase, et les pages statiques avaient `canonical`/`og:url` vers un host mort.

## Correctif
`SITE_URL = https://petite-jerusalem.fr` (le vrai domaine de prod, servi par le projet `petite-jerusalem-dev`) dans :
- `functions/src/index.ts`
- `scripts/prerender-seo.mjs`

## Vérifié en prod
Déployé manuellement (function + hosting) puis testé : pages de détail réparées (plus de « Site Not Found »), `og:title`/`og:description`/`og:url`/`canonical`/`og:image` présents et pointant vers petite-jerusalem.fr.

> ⚠️ À merger avant de pousser un nouveau tag `v*`, sinon le CI redéploierait l'ancien `SITE_URL` et re-casserait la prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)