### PR TITLE
fix(share-reading): texte de timeline lisible en dark mode + invite à se connecter

### DIFF
--- a/src/components/SignupPromptModal.vue
+++ b/src/components/SignupPromptModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter, useRoute } from "vue-router";
 
@@ -9,14 +10,44 @@ const route = useRoute();
 interface Props {
   show: boolean;
   guestEmail?: string;
+  // "reservation": shown after a guest reserves (default).
+  // "auth": shown when a visitor must sign in/up to perform an action
+  //         (e.g. create a session).
+  variant?: "reservation" | "auth";
 }
 
 interface Emits {
   (e: "update:show", value: boolean): void;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  variant: "reservation",
+});
 const emit = defineEmits<Emits>();
+
+// Header + body adapt to the variant. Defaults keep the original
+// "reservation confirmed" appearance so existing usage is unchanged.
+const isAuth = computed(() => props.variant === "auth");
+const headerIcon = computed(() => (isAuth.value ? "fa-circle-plus" : "fa-check"));
+const headerIconWrapClass = computed(() =>
+  isAuth.value
+    ? "bg-primary/10 dark:bg-primary/20"
+    : "bg-green-100 dark:bg-green-900/30",
+);
+const headerIconClass = computed(() =>
+  isAuth.value ? "text-primary" : "text-green-600 dark:text-green-400",
+);
+const title = computed(() =>
+  isAuth.value ? t("signupPrompt.createSessionTitle") : t("signupPrompt.reservationConfirmed"),
+);
+const subtitle = computed(() =>
+  isAuth.value ? t("signupPrompt.createSessionSubtitle") : t("signupPrompt.subtitle"),
+);
+// The benefits list is reservation-specific; keep the auth prompt compact.
+const showBenefits = computed(() => !isAuth.value);
+const footerNote = computed(() =>
+  isAuth.value ? t("signupPrompt.createSessionHaveAccount") : t("signupPrompt.alreadyHaveAccount"),
+);
 
 const closeModal = () => {
   emit("update:show", false);
@@ -48,23 +79,24 @@ const goToLogin = (mode: "signup" | "google" | "login") => {
           class="bg-white rounded-2xl shadow-2xl w-full max-w-md overflow-hidden border border-gray-100 dark:bg-gray-800 dark:border-gray-700 animate-[scaleIn_0.3s_ease]"
           @click.stop
         >
-          <!-- Header avec confirmation -->
+          <!-- Header : confirmation ou invitation à se connecter -->
           <div class="p-6 pb-2 text-center">
             <div
-              class="w-16 h-16 mx-auto mb-4 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center"
+              class="w-16 h-16 mx-auto mb-4 rounded-full flex items-center justify-center"
+              :class="headerIconWrapClass"
             >
-              <i class="fa-solid fa-check text-2xl text-green-600 dark:text-green-400"></i>
+              <i class="fa-solid text-2xl" :class="[headerIcon, headerIconClass]"></i>
             </div>
             <h3 class="text-xl font-bold text-text-primary dark:text-gray-100 mb-1">
-              {{ t("signupPrompt.reservationConfirmed") }}
+              {{ title }}
             </h3>
             <p class="text-sm text-text-secondary dark:text-gray-400">
-              {{ t("signupPrompt.subtitle") }}
+              {{ subtitle }}
             </p>
           </div>
 
           <!-- Liste des avantages -->
-          <div class="px-6 py-4">
+          <div v-if="showBenefits" class="px-6 py-4">
             <div class="space-y-3">
               <div class="flex items-center gap-3">
                 <span
@@ -140,7 +172,7 @@ const goToLogin = (mode: "signup" | "google" | "login") => {
           <!-- Note pour les utilisateurs existants -->
           <div class="px-6 pb-5">
             <p class="text-xs text-center text-text-secondary/70 dark:text-gray-500">
-              {{ t("signupPrompt.alreadyHaveAccount") }}
+              {{ footerNote }}
               <a
                 href="#"
                 class="text-primary font-semibold hover:underline"

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -343,6 +343,9 @@ const en: LocaleMessages = {
   },
   signupPrompt: {
     reservationConfirmed: "Reservation confirmed!",
+    createSessionTitle: "Sign in to create a session",
+    createSessionSubtitle: "Sign up or log in to start your reading share",
+    createSessionHaveAccount: "Already have an account?",
     subtitle: "Just a password away from unlocking all features",
     benefits: {
       recover: "Access your past and future reservations",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -344,6 +344,9 @@ const fr = {
   },
   signupPrompt: {
     reservationConfirmed: "Réservation confirmée !",
+    createSessionTitle: "Connectez-vous pour créer une session",
+    createSessionSubtitle: "Inscrivez-vous ou connectez-vous pour lancer votre partage de lecture",
+    createSessionHaveAccount: "Vous avez déjà un compte ?",
     subtitle: "Plus qu'un mot de passe pour profiter de toutes les fonctionnalités",
     benefits: {
       recover: "Retrouvez vos réservations passées et futures",

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -337,6 +337,9 @@ const he: LocaleMessages = {
   },
   signupPrompt: {
     reservationConfirmed: "ההזמנה אושרה!",
+    createSessionTitle: "התחברו כדי ליצור סשן",
+    createSessionSubtitle: "הירשמו או התחברו כדי להתחיל את שיתוף הקריאה שלכם",
+    createSessionHaveAccount: "כבר יש לך חשבון?",
     subtitle: "רק סיסמה אחת מפרידה בינך לבין כל התכונות",
     benefits: {
       recover: "גש להזמנות העבר והעתיד שלך",

--- a/src/views/ShareReading/ShareHomePage.vue
+++ b/src/views/ShareReading/ShareHomePage.vue
@@ -5,6 +5,7 @@ import { useI18n } from "vue-i18n";
 import { sessionService } from "../../services/sessionService";
 import type { Session } from "../../models/models";
 import SessionCard from "../../components/SessionCard.vue";
+import SignupPromptModal from "../../components/SignupPromptModal.vue";
 import { seoService } from "../../services/seoService";
 import { authService } from "../../services/authService";
 
@@ -15,6 +16,9 @@ const sessions = ref<Session[]>([]);
 const isLoading = ref(true);
 const error = ref<string | null>(null);
 const isAuthenticated = ref(false);
+// Visitors without an account can still click "create a session": instead of a
+// disabled button they get a prompt inviting them to sign in / sign up.
+const showAuthPrompt = ref(false);
 let unsubscribeAuth: (() => void) | null = null;
 
 // Animated "how it works" timeline: plays once when scrolled into view.
@@ -127,6 +131,15 @@ onUnmounted(() => {
 const handleSessionClick = (session: Session) => {
   router.push(`/share-reading/session/${session.slug || session.id}`);
 };
+
+// Logged-in users go straight to the form; visitors get the sign-in prompt.
+const handleCreateClick = () => {
+  if (isAuthenticated.value) {
+    router.push("/share-reading/new-session");
+  } else {
+    showAuthPrompt.value = true;
+  }
+};
 </script>
 
 <template>
@@ -142,18 +155,17 @@ const handleSessionClick = (session: Session) => {
       </p>
 
       <button
-        @click="router.push('/share-reading/new-session')"
-        class="mt-8 px-8 py-3 bg-gradient-to-r from-primary to-secondary text-white font-bold rounded-xl shadow-lg hover:shadow-xl hover:-translate-y-0.5 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none disabled:shadow-none"
-        :disabled="!isAuthenticated"
+        @click="handleCreateClick"
+        class="mt-8 px-8 py-3 bg-gradient-to-r from-primary to-secondary text-white font-bold rounded-xl shadow-lg hover:shadow-xl hover:-translate-y-0.5 transition-all duration-300"
         :title="t('shareReading.createSession')"
       >
         <i class="fa-solid fa-plus mr-2"></i>
         {{ t("shareReading.createSession") }}
       </button>
-      <div v-if="!isAuthenticated" class="mt-4 text-sm text-text-secondary/80 dark:text-gray-400">
-        <small>{{ t("shareReading.authRequired") }}</small>
-      </div>
     </div>
+
+    <!-- Invitation à se connecter pour les visiteurs sans compte -->
+    <SignupPromptModal v-model:show="showAuthPrompt" variant="auth" />
 
     <!-- Comment ça marche : timeline animée -->
     <section class="max-w-5xl mx-auto mb-16">
@@ -175,7 +187,7 @@ const handleSessionClick = (session: Session) => {
           class="timeline__step"
           :style="{ '--i': index }"
         >
-          <span class="timeline__connector" aria-hidden="true">
+          <span class="timeline__connector bg-black/[0.08] dark:bg-white/[0.12]" aria-hidden="true">
             <span class="timeline__fill"></span>
             <span class="timeline__runner"></span>
           </span>
@@ -183,8 +195,10 @@ const handleSessionClick = (session: Session) => {
             <i :class="['fa-solid', step.icon]" aria-hidden="true"></i>
           </span>
           <div class="timeline__content">
-            <h4 class="timeline__title">{{ step.title }}</h4>
-            <p class="timeline__desc">{{ step.description }}</p>
+            <h4 class="timeline__title text-text-primary dark:text-gray-100">{{ step.title }}</h4>
+            <p class="timeline__desc text-text-secondary dark:text-gray-400">
+              {{ step.description }}
+            </p>
           </div>
         </li>
       </ol>
@@ -350,22 +364,17 @@ const handleSessionClick = (session: Session) => {
   grid-column: 2;
   align-self: center;
 }
+/* Title/description colors are set via Tailwind utilities in the template
+   (text-text-* / dark:text-gray-*) so dark mode adapts correctly — Vue's
+   scoped compiler drops the descendant in `:global(.dark) .scoped` rules. */
 .timeline__title {
   font-weight: 700;
   font-size: 1.05rem;
-  color: var(--color-text-primary);
   margin-bottom: 0.2rem;
 }
 .timeline__desc {
   font-size: 0.875rem;
   line-height: 1.55;
-  color: var(--color-text-secondary);
-}
-:global(:root.dark) .timeline__title {
-  color: #f3f4f6;
-}
-:global(:root.dark) .timeline__desc {
-  color: #9ca3af;
 }
 
 /* --- connector (mobile: vertical) --- */
@@ -377,11 +386,8 @@ const handleSessionClick = (session: Session) => {
   width: 3px;
   height: calc(100% - 3rem);
   transform: translateX(-50%);
-  background: rgba(0, 0, 0, 0.08);
   border-radius: 9999px;
-}
-:global(:root.dark) .timeline__connector {
-  background: rgba(255, 255, 255, 0.12);
+  /* track color set via Tailwind (bg-black/[0.08] dark:bg-white/[0.12]) */
 }
 .timeline__step:last-child .timeline__connector {
   display: none;


### PR DESCRIPTION
## Contexte

Deux bugs signalés sur la page **Partage de lecture** :

1. Le texte de la timeline « Comment ça marche » reste noir sur fond sombre en mode dark.
2. Le bouton « Créer une session » est simplement grisé pour les visiteurs non connectés.

## Bug 1 — Timeline illisible en dark mode

Diagnostic via inspection du CSS compilé : les overrides dark étaient écrits en `:global(:root.dark) .timeline__title`, mais le compilateur de styles *scoped* de Vue **supprime le descendant scopé** et émet un `:root.dark { color }` isolé (qui colore le `<html>`, pas le titre). Le texte gardait donc `var(--color-text-primary)` (#333) → quasi-noir sur fond sombre.

**Correctif** : couleurs déplacées vers des utilitaires Tailwind dans le template (`text-text-primary dark:text-gray-100`, `text-text-secondary dark:text-gray-400`), comme le reste de la page. Même correctif pour la couleur de la ligne du connecteur. Vérifié dans le CSS compilé : la variante dark est bien générée dans `@media (prefers-color-scheme: dark)`.

## Bug 2 — Bouton « Créer une session » grisé

Le bouton reste désormais **cliquable**. Au clic, un visiteur non connecté voit une pop-up l'invitant à **s'inscrire / se connecter** (Google, email, ou lien « Se connecter ») qui redirige vers `/login`.

Réutilisation du composant existant `SignupPromptModal` via une nouvelle prop `variant="auth"` (en-tête compact + texte « Connectez-vous pour créer une session »). La valeur par défaut préserve le comportement existant du modal de réservation — pas de régression. Clés i18n `signupPrompt.createSession*` ajoutées en fr/en/he.

## Vérifications

- `npm run type-check` ✅
- `eslint` sur les fichiers modifiés ✅
- `vite build` ✅ (CSS compilé inspecté)
- `vitest run` ✅ 62 tests (dont `i18nUsage` qui valide la cohérence des clés entre langues)

## Note hors périmètre

`tailwind.config.ts` déclare `darkMode: 'selector'`, mais en Tailwind v4 ce fichier n'est pas chargé sans `@config` dans le CSS. Les utilitaires `dark:` réagissent donc à `prefers-color-scheme` (préférence OS) et non à la classe `.dark` du bouton bascule. Ce correctif suit le même mécanisme que le reste du site. Pour que le bouton bascule pilote tout le thème, il suffirait d'ajouter `@custom-variant dark (&:where(.dark, .dark *));` dans `main.css` — non inclus ici car c'est un changement global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014GoeApCzFqC4fRBk9Sa73A)_