### PR TITLE
fix(reading): le bouton Retour ramène à la liste des chapitres

### DIFF
--- a/src/views/TextReading/TextReadingPage.vue
+++ b/src/views/TextReading/TextReadingPage.vue
@@ -79,12 +79,17 @@ async function loadContent() {
   }
 }
 
-function goToSection(index: number) {
-  router.push({
+// Entering a chapter from the list pushes a new entry; paging between chapters
+// (next/previous) replaces it, since moving along is lateral navigation within
+// the same text rather than a new page to step back through.
+function goToSection(index: number, replace = false) {
+  const to = {
     name: "text-reading-section",
     params: { textId: textId.value, section: index },
     query: route.query,
-  });
+  };
+  if (replace) router.replace(to);
+  else router.push(to);
   window.scrollTo({ top: 0 });
 }
 
@@ -94,15 +99,27 @@ function backToSectionList() {
 }
 
 function exitReading() {
-  if (sessionSlug.value) router.push(`/share-reading/session/${sessionSlug.value}`);
-  else router.back();
+  if (sessionSlug.value) {
+    router.push(`/share-reading/session/${sessionSlug.value}`);
+    return;
+  }
+  // While reading a chapter, "back" returns to this text's chapter list rather
+  // than the previously read chapter — readers paging through next/previous
+  // expect to land back on the list to pick another passage.
+  if (!isSingleSection.value && sectionParam.value !== undefined) {
+    backToSectionList();
+    return;
+  }
+  router.back();
 }
 
 function prevSection() {
-  if (content.value && hasPrev.value) goToSection(content.value.sections[sectionIndexInList.value - 1].index);
+  if (content.value && hasPrev.value)
+    goToSection(content.value.sections[sectionIndexInList.value - 1].index, true);
 }
 function nextSection() {
-  if (content.value && hasNext.value) goToSection(content.value.sections[sectionIndexInList.value + 1].index);
+  if (content.value && hasNext.value)
+    goToSection(content.value.sections[sectionIndexInList.value + 1].index, true);
 }
 
 // Sibling texts of the same type (all Tehilim, all tractates…), in catalog order.


### PR DESCRIPTION
## Contexte

Sur les pages de lecture (`/lire/:textId/:section`), le bouton « Retour » du haut faisait un simple retour d'historique. Après avoir enchaîné plusieurs chapitres avec suivant/précédent, il ramenait donc le lecteur au **chapitre précédemment lu** au lieu de la **liste des chapitres** — ce qui n'est pas ce qu'on attend quand on veut aller chercher un autre passage plus loin.

## Changements (`TextReadingPage.vue`)

- **Bouton « Retour »** : en cours de lecture d'un chapitre, il renvoie désormais directement à la **liste des chapitres** du texte (déterministe, correct aussi pour un lien direct / SEO). Sur la liste elle-même (ou un texte à section unique), il garde le retour d'historique normal vers le catalogue. Le mode session continue de renvoyer vers la page de la session.
- **Suivant / Précédent** : la navigation entre chapitres utilise maintenant `router.replace` au lieu de `router.push`. Passer au chapitre suivant est un déplacement *latéral* dans le même texte, pas une nouvelle page. Conséquence : le vrai bouton retour du navigateur (et le geste retour mobile) ramène lui aussi à la liste des chapitres au lieu de remonter chapitre par chapitre.

Le bouton « précédent » dédié continue de reculer d'un chapitre comme avant.

## Vérifications

- `npm run type-check` ✅
- `eslint` sur le fichier modifié ✅
- `vitest run` ✅ 62 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014GoeApCzFqC4fRBk9Sa73A)_