### PR TITLE
fix(reading): le Retour des Tehilim ramène à la liste, pas au psaume précédent

### DIFF
--- a/src/views/TextReading/TextReadingPage.vue
+++ b/src/views/TextReading/TextReadingPage.vue
@@ -136,8 +136,12 @@ const nextText = computed<TextStudyJsonEntry | null>(() =>
     : null,
 );
 
+// Paging to the previous/next sibling text (e.g. Tehilim 5 → Tehilim 6) is
+// lateral navigation, so it replaces the history entry rather than pushing.
+// That way "Retour" (and the browser back button) returns to the list the
+// reader came from instead of stepping back through every text already read.
 function goToText(target: TextStudyJsonEntry) {
-  router.push({ name: "text-reading", params: { textId: String(target.id) }, query: route.query });
+  router.replace({ name: "text-reading", params: { textId: String(target.id) }, query: route.query });
   window.scrollTo({ top: 0 });
 }
 


### PR DESCRIPTION
## Contexte

Suite à la version précédente, le « Retour » fonctionnait pour les textes multi-chapitres, mais **pas pour les Tehilim** — le cas le plus utilisé. En ouvrant l'onglet Études → liste des Tehilim → un psaume → suivant, suivant, suivant, le bouton « Retour » se comportait comme « précédent » (revenait au psaume d'avant) au lieu de ramener à la liste complète.

## Cause

Chaque Tehilim est un **texte distinct** (« Tehilim 1 », « Tehilim 2 »…), pas un chapitre d'un même texte. La navigation suivant/précédent entre eux passe par `goToText`, que le correctif précédent n'avait pas touché : il faisait toujours `router.push`. Chaque « suivant » empilait donc une entrée d'historique, et `router.back()` revenait au psaume précédent.

## Correctif (`TextReadingPage.vue`)

`goToText` utilise désormais `router.replace` au lieu de `router.push`, comme la navigation entre chapitres : passer au texte frère suivant/précédent est un déplacement *latéral*. Le bouton « Retour » (et le bouton retour du navigateur) ramène à la liste d'où vient le lecteur.

## Vérifications

- `npm run type-check` ✅
- `eslint` sur le fichier modifié ✅
- `vitest run` ✅ 62 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014GoeApCzFqC4fRBk9Sa73A)_