### PR TITLE
Ajoute les numéros hébraïques (guématria) à côté des numéros de textes

### DIFF
--- a/src/__tests__/hebrewNumerals.test.ts
+++ b/src/__tests__/hebrewNumerals.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  toHebrewNumeral,
+  formatNumberWithHebrew,
+  appendHebrewNumeral,
+} from "../services/hebrewNumerals";
+
+describe("toHebrewNumeral", () => {
+  it("convertit les unités (lettre seule, sans marque)", () => {
+    expect(toHebrewNumeral(1)).toBe("א");
+    expect(toHebrewNumeral(5)).toBe("ה");
+    expect(toHebrewNumeral(9)).toBe("ט");
+  });
+
+  it("convertit les dizaines et centaines seules", () => {
+    expect(toHebrewNumeral(10)).toBe("י");
+    expect(toHebrewNumeral(100)).toBe("ק");
+  });
+
+  it("insère un guershayim avant la dernière lettre des nombres composés", () => {
+    expect(toHebrewNumeral(11)).toBe("י״א");
+    expect(toHebrewNumeral(21)).toBe("כ״א");
+    expect(toHebrewNumeral(150)).toBe("ק״נ");
+  });
+
+  it("écrit 15 et 16 en ט״ו / ט״ז pour éviter le nom divin", () => {
+    expect(toHebrewNumeral(15)).toBe("ט״ו");
+    expect(toHebrewNumeral(16)).toBe("ט״ז");
+    expect(toHebrewNumeral(115)).toBe("קט״ו");
+  });
+
+  it("gère les Tehilim jusqu'à 150", () => {
+    expect(toHebrewNumeral(119)).toBe("קי״ט");
+    // Pas de forme finale (sofit) : 120 → ק״כ, jamais ק״ך.
+    expect(toHebrewNumeral(120)).toBe("ק״כ");
+  });
+
+  it("laisse passer les valeurs non entières ou non positives", () => {
+    expect(toHebrewNumeral(0)).toBe("0");
+    expect(toHebrewNumeral(-3)).toBe("-3");
+    expect(toHebrewNumeral(1.5)).toBe("1.5");
+  });
+});
+
+describe("formatNumberWithHebrew", () => {
+  it("affiche le chiffre puis la lettre entre parenthèses", () => {
+    expect(formatNumberWithHebrew(5)).toBe("5 (ה)");
+    expect(formatNumberWithHebrew(119)).toBe("119 (קי״ט)");
+  });
+});
+
+describe("appendHebrewNumeral", () => {
+  it("ajoute la guématria à un nom se terminant par un nombre", () => {
+    expect(appendHebrewNumeral("Tehilim 5")).toBe("Tehilim 5 (ה)");
+    expect(appendHebrewNumeral("Tehilim 150")).toBe("Tehilim 150 (ק״נ)");
+  });
+
+  it("laisse les noms sans nombre final inchangés", () => {
+    expect(appendHebrewNumeral("ברכות (Berakhot)")).toBe("ברכות (Berakhot)");
+    expect(appendHebrewNumeral("Mishna Berachot")).toBe("Mishna Berachot");
+  });
+});

--- a/src/services/hebrewNumerals.ts
+++ b/src/services/hebrewNumerals.ts
@@ -1,0 +1,50 @@
+/**
+ * Hebrew numerals (gematria) for chapter / psalm numbers.
+ *
+ * Texts here are numbered with Arabic digits ("Tehilim 119", "Chapitre 5"), but
+ * Hebrew sources traditionally number them with letters (תהילים קי״ט). This renders
+ * that traditional form next to the digits as a reading aid for Hebrew readers.
+ *
+ * Single-letter values are left bare (5 → ה); multi-letter values take a gershayim
+ * before the last letter (119 → קי״ט) so they read as a number rather than a word.
+ * 15 and 16 are written ט״ו / ט״ז rather than יה / יו, which spell parts of the
+ * divine name.
+ */
+
+const UNITS = ["", "א", "ב", "ג", "ד", "ה", "ו", "ז", "ח", "ט"];
+const TENS = ["", "י", "כ", "ל", "מ", "נ", "ס", "ע", "פ", "צ"];
+// Index 0–4 → 0, 100, 200, 300, 400. Higher hundreds stack onto ת (400).
+const HUNDREDS = ["", "ק", "ר", "ש", "ת"];
+
+const GERSHAYIM = "״";
+
+/** Hebrew letters for a number 1–999, with 15/16 written ט״ו/ט״ז (not יה/יו). */
+function lettersFor(n: number): string {
+  const hundreds = Math.floor(n / 100);
+  let out = "ת".repeat(Math.floor(hundreds / 4)) + HUNDREDS[hundreds % 4];
+  const rest = n % 100;
+  if (rest === 15) return out + "טו";
+  if (rest === 16) return out + "טז";
+  out += TENS[Math.floor(rest / 10)] + UNITS[rest % 10];
+  return out;
+}
+
+/** Converts a positive integer to its Hebrew numeral (gematria). Other values pass through. */
+export function toHebrewNumeral(n: number): string {
+  if (!Number.isInteger(n) || n <= 0) return String(n);
+  const letters = lettersFor(n);
+  if (letters.length === 1) return letters;
+  return letters.slice(0, -1) + GERSHAYIM + letters.slice(-1);
+}
+
+/** "5" → "5 (ה)": Arabic number with its Hebrew numeral in parentheses. */
+export function formatNumberWithHebrew(n: number): string {
+  return `${n} (${toHebrewNumeral(n)})`;
+}
+
+/** Appends the Hebrew numeral to a name ending in a number ("Tehilim 5" → "Tehilim 5 (ה)"). */
+export function appendHebrewNumeral(name: string): string {
+  const match = name.match(/(\d+)\s*$/);
+  if (!match) return name;
+  return `${name} (${toHebrewNumeral(Number(match[1]))})`;
+}

--- a/src/services/textService.ts
+++ b/src/services/textService.ts
@@ -1,4 +1,5 @@
 import type { TextStudyJsonEntry } from "../models/models";
+import { formatNumberWithHebrew } from "./hebrewNumerals";
 
 /**
  * Loads the locally-stored texts under `public/texts/`.
@@ -122,7 +123,7 @@ function buildSection(index: number, label: string, he: string[]): TextSection {
 /** Splits a he[chapter][verse] array into one section per non-empty chapter. */
 function chaptersToSections(heChapters: unknown[]): TextSection[] {
   return heChapters
-    .map((chapter, i) => buildSection(i + 1, `Chapitre ${i + 1}`, normalizeLines(chapter)))
+    .map((chapter, i) => buildSection(i + 1, `Chapitre ${formatNumberWithHebrew(i + 1)}`, normalizeLines(chapter)))
     .filter((s) => s.he.length > 0);
 }
 
@@ -156,10 +157,11 @@ async function loadTalmud(
         lines.push(...dafLines);
         dafBlocks.push({ daf: `${Math.floor(i / 2) + 2}${i % 2 === 0 ? "a" : "b"}`, lines: dafLines });
       }
-      const label =
+      const dafRange =
         range.startDaf === range.endDaf
-          ? `Chapitre ${range.chapter} (Daf ${range.startDaf})`
-          : `Chapitre ${range.chapter} (Daf ${range.startDaf}–${range.endDaf})`;
+          ? `Daf ${range.startDaf}`
+          : `Daf ${range.startDaf}–${range.endDaf}`;
+      const label = `Chapitre ${formatNumberWithHebrew(range.chapter)} · ${dafRange}`;
       return { index: range.chapter, label, he: lines, dafBlocks };
     });
     return { title, type: "Talmud Bavli", sections };

--- a/src/views/SessionManagementPage.vue
+++ b/src/views/SessionManagementPage.vue
@@ -4,6 +4,7 @@ import { useRouter } from "vue-router";
 import { sessionService } from "../services/sessionService";
 import { reservationService, type ReservationForm } from "../services/reservationService";
 import { authService } from "../services/authService";
+import { appendHebrewNumeral, formatNumberWithHebrew } from "../services/hebrewNumerals";
 import type { Session, TextStudy } from "../models/models";
 import type { User } from "../services/authService";
 import { seoService } from "../services/seoService";
@@ -441,7 +442,7 @@ onMounted(() => {
               >
                 <div class="flex justify-between items-start gap-4 mb-2">
                   <h4 class="font-bold text-lg text-text-primary leading-tight dark:text-gray-100">
-                    {{ sessionService.formatBookName(textStudy.name) }}
+                    {{ appendHebrewNumeral(sessionService.formatBookName(textStudy.name)) }}
                   </h4>
                   <span
                     class="px-2 py-1 text-xs font-bold uppercase rounded-md whitespace-nowrap"
@@ -505,7 +506,7 @@ onMounted(() => {
                   >
                     <div class="flex flex-col min-w-0">
                       <span class="font-medium text-text-primary dark:text-gray-200">
-                        {{ textStudy.totalSections > 1 ? `Chapitre ${section}` : "Texte complet" }}
+                        {{ textStudy.totalSections > 1 ? `Chapitre ${formatNumberWithHebrew(section)}` : "Texte complet" }}
                       </span>
                       <span
                         v-if="isSectionReserved(textStudy.id, section)"
@@ -616,9 +617,9 @@ onMounted(() => {
             class="p-3 bg-primary/10 rounded-xl text-sm text-text-primary mb-2 dark:bg-primary/20 dark:text-white"
           >
             <span class="font-semibold">{{
-              sessionService.formatBookName(selectedTextStudy?.name || "")
+              appendHebrewNumeral(sessionService.formatBookName(selectedTextStudy?.name || ""))
             }}</span>
-            <span v-if="selectedSection"> - Chapitre {{ selectedSection }}</span>
+            <span v-if="selectedSection"> - Chapitre {{ formatNumberWithHebrew(selectedSection) }}</span>
           </div>
 
           <div>

--- a/src/views/ShareReading/detailSession/TextStudiesList.vue
+++ b/src/views/ShareReading/detailSession/TextStudiesList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { sessionService } from "../../../services/sessionService";
+import { appendHebrewNumeral, formatNumberWithHebrew } from "../../../services/hebrewNumerals";
 import { ref } from "vue";
 import type { Session, TextStudy, TextStudyReservation } from "../../../models/models";
 import type { User } from "../../../services/authService";
@@ -127,9 +128,9 @@ const handleCardClick = (text: TextStudy) => {
               <div class="flex-1 min-w-0">
                 <h4
                   class="font-bold text-lg text-text-primary leading-tight truncate mb-1 dark:text-gray-100"
-                  :title="text.name"
+                  :title="appendHebrewNumeral(text.name)"
                 >
-                  {{ text.name }}
+                  {{ appendHebrewNumeral(text.name) }}
                 </h4>
                 <!-- Case à cocher directe pour les textes à un seul chapitre -->
                 <label
@@ -322,7 +323,7 @@ const handleCardClick = (text: TextStudy) => {
                     "
                   />
                   <span class="font-medium text-sm text-text-primary dark:text-gray-200"
-                    >Chapitre {{ chapter }}</span
+                    >Chapitre {{ formatNumberWithHebrew(chapter) }}</span
                   >
                 </div>
 

--- a/src/views/StudyPage.vue
+++ b/src/views/StudyPage.vue
@@ -5,6 +5,7 @@ import textStudiesJson from "../datas/textStudies.json";
 import type { TextStudiesJson, TextStudyJsonEntry } from "../models/models";
 import { sessionService } from "../services/sessionService";
 import { seoService } from "../services/seoService";
+import { appendHebrewNumeral } from "../services/hebrewNumerals";
 
 const { t } = useI18n();
 
@@ -122,7 +123,7 @@ onMounted(() => {
           >
             <span class="min-w-0">
               <span class="block font-medium text-text-primary truncate dark:text-gray-200">
-                {{ text.name }}
+                {{ appendHebrewNumeral(text.name) }}
               </span>
               <span
                 v-if="text.totalSections > 1"

--- a/src/views/TextReading/TextReadingPage.vue
+++ b/src/views/TextReading/TextReadingPage.vue
@@ -13,6 +13,7 @@ import type { User } from "../../services/authService";
 import { loadText, MissingTextFileError } from "../../services/textService";
 import type { TextContent, TextSection } from "../../services/textService";
 import { transliterate, hasNiqqud } from "../../services/hebrewTransliteration";
+import { appendHebrewNumeral } from "../../services/hebrewNumerals";
 import { sessionService } from "../../services/sessionService";
 import { seoService } from "../../services/seoService";
 import GuestForm from "../../components/GuestForm.vue";
@@ -242,7 +243,7 @@ async function toggleRead() {
 const pageTitle = computed(() => {
   if (!textEntry.value) return "Lecture | Petite Jérusalem";
   const sec = currentSection.value && !isSingleSection.value ? ` · ${currentSection.value.label}` : "";
-  return `${textEntry.value.name}${sec} | Petite Jérusalem`;
+  return `${appendHebrewNumeral(textEntry.value.name)}${sec} | Petite Jérusalem`;
 });
 watch(pageTitle, (title) => seoService.setMeta({ title }), { immediate: true });
 
@@ -304,7 +305,7 @@ watch(textId, loadContent);
       <p class="text-text-secondary mb-1 max-w-sm dark:text-gray-400">
         {{ t("textReading.missingDescription") }}
       </p>
-      <p class="text-xs text-text-secondary/60 dark:text-gray-600">{{ textEntry.name }}</p>
+      <p class="text-xs text-text-secondary/60 dark:text-gray-600">{{ appendHebrewNumeral(textEntry.name) }}</p>
     </div>
 
     <div
@@ -331,7 +332,7 @@ watch(textId, loadContent);
           {{ textEntry.livre }}
         </p>
         <h1 class="text-3xl md:text-4xl font-bold text-text-primary dark:text-gray-100">
-          {{ textEntry.name }}
+          {{ appendHebrewNumeral(textEntry.name) }}
         </h1>
         <p
           v-if="currentSection && !isSingleSection"
@@ -345,8 +346,8 @@ watch(textId, loadContent);
       <div v-if="showSectionList">
         <ReadingNav
           v-if="prevText || nextText"
-          :prev-label="prevText?.name ?? null"
-          :next-label="nextText?.name ?? null"
+          :prev-label="prevText ? appendHebrewNumeral(prevText.name) : null"
+          :next-label="nextText ? appendHebrewNumeral(nextText.name) : null"
           @prev="prevText && goToText(prevText)"
           @next="nextText && goToText(nextText)"
           class="mb-6 pb-5 border-b border-black/5 dark:border-white/10"
@@ -389,8 +390,8 @@ watch(textId, loadContent);
         </div>
         <ReadingNav
           v-if="prevText || nextText"
-          :prev-label="prevText?.name ?? null"
-          :next-label="nextText?.name ?? null"
+          :prev-label="prevText ? appendHebrewNumeral(prevText.name) : null"
+          :next-label="nextText ? appendHebrewNumeral(nextText.name) : null"
           @prev="prevText && goToText(prevText)"
           @next="nextText && goToText(nextText)"
           class="mt-8 pt-6 border-t border-black/5 dark:border-white/10"
@@ -512,8 +513,8 @@ watch(textId, loadContent);
         />
         <ReadingNav
           v-else-if="prevText || nextText"
-          :prev-label="prevText?.name ?? null"
-          :next-label="nextText?.name ?? null"
+          :prev-label="prevText ? appendHebrewNumeral(prevText.name) : null"
+          :next-label="nextText ? appendHebrewNumeral(nextText.name) : null"
           @prev="prevText && goToText(prevText)"
           @next="nextText && goToText(nextText)"
           class="mb-6 pb-5 border-b border-black/5 dark:border-white/10"
@@ -620,8 +621,8 @@ watch(textId, loadContent);
         />
         <ReadingNav
           v-else-if="prevText || nextText"
-          :prev-label="prevText?.name ?? null"
-          :next-label="nextText?.name ?? null"
+          :prev-label="prevText ? appendHebrewNumeral(prevText.name) : null"
+          :next-label="nextText ? appendHebrewNumeral(nextText.name) : null"
           @prev="prevText && goToText(prevText)"
           @next="nextText && goToText(nextText)"
           class="mt-10 pt-6 border-t border-black/5 dark:border-white/10"

--- a/src/views/profilePage/ParticipatedSessions.vue
+++ b/src/views/profilePage/ParticipatedSessions.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { sessionService } from "../../services/sessionService";
+import { appendHebrewNumeral, formatNumberWithHebrew } from "../../services/hebrewNumerals";
 import type { Session, TextStudy } from "../../models/models";
 import type { User } from "../../services/authService";
 
@@ -42,7 +43,7 @@ const getUserReservationsForSession = (session: Session) => {
 
 const getTextStudyName = (textStudyId: string): string => {
   const textStudy = props.textStudiesMap.get(textStudyId);
-  return textStudy ? textStudy.name : textStudyId;
+  return textStudy ? appendHebrewNumeral(textStudy.name) : textStudyId;
 };
 
 const toggleReservationCompletion = async (
@@ -173,7 +174,7 @@ const goToSession = (slugOrId: string) => {
                         v-if="reservation.section"
                         class="text-text-secondary font-normal dark:text-gray-400"
                       >
-                        - {{ t("common.chapter") }} {{ reservation.section }}
+                        - {{ t("common.chapter") }} {{ formatNumberWithHebrew(reservation.section) }}
                       </span>
                     </span>
                     <span


### PR DESCRIPTION
## Contexte

Suite à l'ajout des textes en local, des lecteurs ont demandé d'avoir aussi la numérotation traditionnelle en lettres hébraïques (guématria), en plus des chiffres arabes (ex. les téhilim numérotés 1 à 150).

## Changements

- **Nouvel utilitaire `src/services/hebrewNumerals.ts`** : conversion d'un nombre en guématria.
  - Guershayim (״) inséré avant la dernière lettre des nombres composés (ex. `119` → `קי״ט`).
  - Cas particuliers **ט״ו (15)** et **ט״ז (16)** pour ne pas écrire les lettres du nom divin.
  - Pas de formes finales (ex. `150` → `ק״נ`).
- **Affichage de la lettre entre parenthèses, à côté du chiffre**, partout où un numéro de texte apparaît :
  - Catalogue d'étude, page de lecture (en-tête, titre d'onglet, navigation précédent/suivant)
  - Libellés de chapitre des Mishna/Talmud/Tanakh (ex. `Chapitre 119 (קי״ט)`)
  - Listes et page de gestion de session, réservations du profil
- Les données (`textStudies.json`) **ne sont pas modifiées** : le rendu est calculé à l'affichage.
- **Tests unitaires** pour la guématria (cas standards + ט״ו/ט״ז + noms).

## Exemples de rendu

- `Tehilim 5 (ה)`
- `Tehilim 119 (קי״ט)`
- `Chapitre 150 (ק״נ)`

## Vérifications

- `vue-tsc` ✅
- ESLint ✅
- Tests : 71/71 ✅ (dont 9 nouveaux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnYf9VevY46EXP1YWq6nQW)_