### PR TITLE
feat(seo): les 6 autres pages « Tehilim par intention »

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,6 +9,7 @@ Mots-clés : partage de lecture, partage d'étude, finir le Chass, terminer le T
 - [Partage de lectures](https://petite-jerusalem.fr/share-reading) : créer une session, choisir un texte, répartir les passages entre participants et suivre la progression.
 - [Finir le Chass à plusieurs](https://petite-jerusalem.fr/finir-le-chass) : organiser l'étude collective du Talmud Bavli jusqu'au siyoum haShass.
 - [Partage de Tehilim](https://petite-jerusalem.fr/partage-tehilim) : répartir les 150 Psaumes entre plusieurs personnes.
+- [Tehilim par intention](https://petite-jerusalem.fr/tehilim) : quels psaumes lire selon l'intention (refoua chelema / guérison d'un malade, etc.) et comment les partager à plusieurs.
 - [Étude](https://petite-jerusalem.fr/etude) : lire les Tehilim, la Michna, le Talmud et le Tanakh en ligne, en hébreu et en phonétique.
 - [Chiourim](https://petite-jerusalem.fr/chiourim) : cours et leçons de Torah à écouter, par rav ou par thème.
 

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -25,7 +25,7 @@
  * environment-agnostic module) so the Vue app and this build step share one
  * source of truth. It is a TypeScript file, loaded here through `jiti`.
  */
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createJiti } from "jiti";
@@ -45,9 +45,13 @@ function main() {
   writeFileSync(join(dist, "app.html"), template, "utf-8");
 
   // 2. One static HTML file per indexable page (body + head + JSON-LD).
+  //    Some pages live in a subfolder (e.g. tehilim/refoua-chelema.html), so
+  //    make sure the target directory exists before writing.
   for (const page of allPages) {
     const html = renderPage(template, page);
-    writeFileSync(join(dist, page.file), html, "utf-8");
+    const target = join(dist, page.file);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, html, "utf-8");
     console.log(`[prerender-seo] ${page.path} -> dist/${page.file}`);
   }
 

--- a/src/__tests__/prerenderSeo.test.ts
+++ b/src/__tests__/prerenderSeo.test.ts
@@ -8,6 +8,9 @@ import {
   allPages,
   appPages,
   landingPages,
+  tehilimHub,
+  tehilimIntentionPages,
+  tehilimPages,
   SITE_URL,
   type SeoPage,
 } from "../content/seoPages";
@@ -130,6 +133,51 @@ describe("seoPages data", () => {
 
   it("cible le bon domaine canonique", () => {
     expect(SITE_URL).toBe("https://petite-jerusalem.fr");
+  });
+});
+
+describe("seoPages Tehilim par intention", () => {
+  it("expose le hub /tehilim et l'ajoute aux pages prérendues + sitemap", () => {
+    expect(tehilimHub.path).toBe("/tehilim");
+    expect(tehilimHub.file).toBe("tehilim.html");
+    expect(allPages).toContain(tehilimHub);
+    expect(buildSitemap("2026-06-21")).toContain(
+      "<loc>https://petite-jerusalem.fr/tehilim</loc>",
+    );
+  });
+
+  it("inclut au moins la page modèle refoua-chelema", () => {
+    const refoua = tehilimIntentionPages.find((p) => p.path === "/tehilim/refoua-chelema");
+    expect(refoua).toBeDefined();
+    expect(refoua!.file).toBe("tehilim/refoua-chelema.html");
+  });
+
+  it("chaque page intention lie vers le lecteur, le partage et le hub", () => {
+    for (const p of tehilimIntentionPages) {
+      expect(p.bodyHtml).toMatch(/href="\/lire\/\d+"/);
+      expect(p.bodyHtml).toContain('href="/share-reading/new-session"');
+      expect(p.bodyHtml).toContain('href="/tehilim"');
+      expect(p.bodyHtml).toContain('href="/partage-tehilim"');
+    }
+  });
+
+  it("émet le JSON-LD BreadcrumbList + FAQPage sur les pages intention", () => {
+    for (const p of tehilimIntentionPages) {
+      const types = (p.jsonLd ?? []).map((o) => o["@type"]);
+      expect(types).toContain("BreadcrumbList");
+      expect(types).toContain("FAQPage");
+    }
+  });
+
+  it("le hub liste chaque intention disponible", () => {
+    for (const p of tehilimIntentionPages) {
+      expect(tehilimHub.bodyHtml).toContain(`href="${p.path}"`);
+    }
+  });
+
+  it("tehilimPages regroupe le hub puis les intentions", () => {
+    expect(tehilimPages[0]).toBe(tehilimHub);
+    expect(tehilimPages.slice(1)).toEqual(tehilimIntentionPages);
   });
 });
 

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -197,6 +197,39 @@ button,
   color: #cbd5e1;
 }
 
+/* "Tehilim par intention": horizontal list of psalm chips linking to the reader. */
+.seo-article .tehilim-psalms {
+  list-style: none;
+  margin-inline-start: 0;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.seo-article .tehilim-psalms li {
+  margin: 0;
+}
+
+.seo-article .tehilim-psalms a {
+  display: inline-block;
+  padding: 0.4rem 0.85rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+:root.dark .seo-article .tehilim-psalms a {
+  background: rgba(31, 41, 55, 0.5);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.seo-article .seo-note {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
 /* Internal-link footer injected into prerendered HTML only (the SPA uses
    SiteFooter.vue). Kept visually quiet. */
 .seo-footer {

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -22,6 +22,9 @@
       <RouterLink class="hover:text-primary transition-colors" to="/partage-tehilim">{{
         t("footer.shareTehilim")
       }}</RouterLink>
+      <RouterLink class="hover:text-primary transition-colors" to="/tehilim">{{
+        t("footer.tehilimIntentions")
+      }}</RouterLink>
     </nav>
 
     <div

--- a/src/content/seoPages.ts
+++ b/src/content/seoPages.ts
@@ -95,6 +95,7 @@ export const staticFooterHtml = `
       <a href="/chiourim">Chiourim</a>
       <a href="/finir-le-chass">Finir le Chass</a>
       <a href="/partage-tehilim">Partage de Tehilim</a>
+      <a href="/tehilim">Tehilim par intention</a>
     </nav>
     <p>Petite Jérusalem : étudier et partager la Torah, ensemble. Gratuit et en français.</p>
   </footer>`;
@@ -725,8 +726,231 @@ const landingAsSeoPages: SeoPage[] = landingPages.map((p) => ({
   ...p.locales[DEFAULT_LANDING_LOCALE],
 }));
 
+// ---- Tehilim par intention (hub + intention pages) ----------------------
+//
+// Evergreen utility pages answering "which Tehilim to read for …" queries
+// (a malade / refoua chelema, mariage, parnassa…). Each page lists the
+// traditionally-read psalms (linked to the full reader) and converts to a
+// shared reading. French-only for now (the brief defers i18n). The psalm
+// lists are provisional and to be revalidated by a competent person, so each
+// page carries a prudent disclaimer.
+
+const TEHILIM_HUB_PATH = "/tehilim";
+const SHARE_NEW_SESSION = "/share-reading/new-session";
+
+/** The Tehilim reader serves chapter N at textId 102 + N (see textStudies.json). */
+const tehilimReaderHref = (n: number): string => `/lire/${102 + n}`;
+
+const intentionPath = (slug: string): string => `${TEHILIM_HUB_PATH}/${slug}`;
+
+type Intention = {
+  /** URL slug, lowercase and without accents (e.g. "refoua-chelema"). */
+  slug: string;
+  title: string;
+  description: string;
+  h1: string;
+  /** Intro paragraph(s), inline HTML. */
+  lead: string;
+  /** Recommended psalm numbers, in reading order. */
+  psalms: number[];
+  /** Optional extra note shown under the psalm list (inline HTML). */
+  psalmsNote?: string;
+  /** Short label + blurb used on the hub card and breadcrumb. */
+  cardTitle: string;
+  cardDesc: string;
+  /** Slugs of related intentions for internal linking (unknown slugs are ignored). */
+  related: string[];
+  faq: { q: string; a: string }[];
+};
+
+/** Prudent disclaimer shown on every intention page (lists pending revalidation). */
+const TEHILIM_DISCLAIMER =
+  "Ces listes sont indicatives, selon les sources couramment citées, et en cours de revalidation. En cas de doute, demandez conseil à votre rav.";
+
+const INTENTIONS: Intention[] = [
+  {
+    slug: "refoua-chelema",
+    title: "Tehilim pour un malade (refoua chelema) | Petite Jérusalem",
+    description:
+      "Quels Tehilim lire pour la refoua chelema (guérison d'un malade) : psaumes 20, 121, 6, 30 et 38, à lire seul ou à plusieurs pour aller plus vite.",
+    h1: "Tehilim pour la guérison d'un malade (refoua chelema)",
+    lead: "La <strong>refoua chelema</strong> est la prière pour la guérison complète d'un malade. On a coutume de lire certains Tehilim (Psaumes) en pensant à la personne souffrante. Lus à plusieurs, en se répartissant les chapitres, ils se terminent bien plus vite.",
+    psalms: [20, 121, 6, 30, 38],
+    psalmsNote:
+      "L'usage est de prier pour la personne avec son prénom hébraïque suivi de celui de sa mère (par ex. «&nbsp;Untel ben Unetelle&nbsp;»). Beaucoup ajoutent le psaume 119 selon les lettres du prénom du malade.",
+    cardTitle: "Refoua chelema (guérison d'un malade)",
+    cardDesc: "Les psaumes à lire pour la guérison d'une personne malade.",
+    related: ["accouchement", "protection"],
+    faq: [
+      {
+        q: "Quels Tehilim lire pour un malade ?",
+        a: "On lit traditionnellement les psaumes 20, 121, 6, 30 et 38 pour une refoua chelema. Beaucoup ajoutent le psaume 119 selon les lettres du prénom du malade. En cas de doute, demandez conseil à votre rav.",
+      },
+      {
+        q: "Comment lire les Tehilim pour la guérison à plusieurs ?",
+        a: "Créez une session de partage de Tehilim sur Petite Jérusalem, indiquez le nom du malade, puis partagez le lien. Chacun lit quelques psaumes et l'on termine bien plus vite, ensemble.",
+      },
+      {
+        q: "Faut-il mentionner le nom du malade ?",
+        a: "L'usage est de prier pour la personne en utilisant son prénom hébraïque suivi de celui de sa mère (par ex. « Untel ben Unetelle »). Vous pouvez l'indiquer dans la description de la session de partage.",
+      },
+      {
+        q: "Est-ce gratuit ?",
+        a: "Oui, Petite Jérusalem est entièrement gratuit, et l'on peut participer même sans créer de compte.",
+      },
+    ],
+  },
+];
+
+const intentionBySlug = new Map(INTENTIONS.map((i) => [i.slug, i]));
+
+/** Build one intention page (body + head metadata + JSON-LD) as a SeoPage. */
+function buildIntention(it: Intention): SeoPage {
+  const path = intentionPath(it.slug);
+
+  const psalmsList = it.psalms
+    .map((n) => `<li><a href="${tehilimReaderHref(n)}">Tehilim ${n}</a></li>`)
+    .join("\n        ");
+
+  const related = it.related
+    .map((slug) => intentionBySlug.get(slug))
+    .filter((r): r is Intention => Boolean(r))
+    .map((r) => `<li><a href="${intentionPath(r.slug)}">${r.cardTitle}</a></li>`)
+    .join("\n        ");
+
+  const bodyHtml = `
+  <main class="seo-article">
+    <h1>${it.h1}</h1>
+    <p class="seo-lead">${it.lead}</p>
+
+    <p><a class="seo-cta" href="${SHARE_NEW_SESSION}">Organiser un partage de Tehilim pour cette intention</a></p>
+
+    <section class="seo-section" aria-labelledby="psaumes-title">
+      <h2 id="psaumes-title">Psaumes (Tehilim) à lire</h2>
+      <p>Psaumes traditionnellement lus pour cette intention&nbsp;:</p>
+      <ul class="tehilim-psalms">
+        ${psalmsList}
+      </ul>
+      ${it.psalmsNote ? `<p>${it.psalmsNote}</p>` : ""}
+      <p class="seo-note"><em>${TEHILIM_DISCLAIMER}</em></p>
+    </section>
+
+    <section class="seo-section">
+      <h2>Comment partager ces Tehilim</h2>
+      <ol>
+        <li>Créez une <a href="${SHARE_NEW_SESSION}">session de partage</a> de type Tehilim et précisez l'intention (et le nom concerné) dans la description.</li>
+        <li>Sélectionnez les chapitres à lire, ou tout le sefer Tehilim.</li>
+        <li>Partagez le lien avec votre famille, vos amis ou votre communauté&nbsp;: chacun réserve et lit ses chapitres, même sans compte.</li>
+        <li>Suivez la progression en temps réel jusqu'à terminer les Tehilim ensemble.</li>
+      </ol>
+      <p><a class="seo-cta" href="${SHARE_NEW_SESSION}">Organiser un partage de Tehilim</a></p>
+    </section>
+
+    ${faqHtml(it.faq, "Questions fréquentes")}
+
+    <section class="seo-section">
+      <h2>Autres intentions &amp; ressources</h2>
+      <ul>
+        ${related ? related + "\n        " : ""}<li><a href="${TEHILIM_HUB_PATH}">Toutes les intentions (Tehilim par intention)</a></li>
+        <li><a href="/partage-tehilim">Partage de Tehilim à plusieurs</a></li>
+        <li><a href="/etude">Étude libre des textes</a></li>
+      </ul>
+    </section>
+  </main>`;
+
+  return {
+    file: `tehilim/${it.slug}.html`,
+    path,
+    title: it.title,
+    description: it.description,
+    sitemap: { priority: 0.8, changefreq: "monthly" },
+    bodyHtml,
+    jsonLd: [
+      breadcrumb([
+        { name: "Accueil", path: "/" },
+        { name: "Tehilim par intention", path: TEHILIM_HUB_PATH },
+        { name: it.cardTitle, path },
+      ]),
+      faqJsonLd(it.faq),
+    ],
+  };
+}
+
+/** Build the hub page listing every intention. */
+function buildTehilimHub(): SeoPage {
+  const cards = INTENTIONS.map(
+    (it) => `
+        <li>
+          <h3><a href="${intentionPath(it.slug)}">${it.cardTitle}</a></h3>
+          <p>${it.cardDesc}</p>
+        </li>`,
+  ).join("");
+
+  const bodyHtml = `
+  <main class="seo-article">
+    <h1>Tehilim par intention</h1>
+    <p class="seo-lead">
+      À chaque moment de la vie correspondent des Tehilim (Psaumes) que l'on a coutume de lire&nbsp;:
+      pour la guérison d'un malade, à la mémoire d'un défunt, pour la subsistance ou la protection…
+      Retrouvez les psaumes traditionnellement lus pour chaque intention, et organisez un partage
+      pour les terminer à plusieurs.
+    </p>
+
+    <p><a class="seo-cta" href="${SHARE_NEW_SESSION}">Organiser un partage de Tehilim</a></p>
+
+    <section class="seo-section">
+      <h2>Choisir une intention</h2>
+      <ul class="seo-cards">${cards}
+      </ul>
+    </section>
+
+    <section class="seo-section">
+      <h2>Lire les Tehilim à plusieurs</h2>
+      <p>
+        Lire un sefer Tehilim entier (150 psaumes) prend du temps&nbsp;; en se répartissant les
+        chapitres, un groupe peut le terminer en quelques minutes. Découvrez comment
+        <a href="/partage-tehilim">partager les Tehilim à plusieurs</a> ou lancez directement une
+        <a href="${SHARE_NEW_SESSION}">session de partage</a>.
+      </p>
+      <p class="seo-note"><em>${TEHILIM_DISCLAIMER}</em></p>
+    </section>
+  </main>`;
+
+  return {
+    file: "tehilim.html",
+    path: TEHILIM_HUB_PATH,
+    title: "Tehilim par intention : quels psaumes lire et pourquoi | Petite Jérusalem",
+    description:
+      "Quels Tehilim (Psaumes) lire selon l'intention : guérison d'un malade (refoua chelema), à la mémoire d'un défunt, parnassa, protection… Listes des psaumes et partage à plusieurs.",
+    sitemap: { priority: 0.9, changefreq: "monthly" },
+    bodyHtml,
+    jsonLd: [
+      breadcrumb([
+        { name: "Accueil", path: "/" },
+        { name: "Tehilim par intention", path: TEHILIM_HUB_PATH },
+      ]),
+      {
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        name: "Tehilim par intention",
+        itemListElement: INTENTIONS.map((it, i) => ({
+          "@type": "ListItem",
+          position: i + 1,
+          name: it.cardTitle,
+          url: `${SITE_URL}${intentionPath(it.slug)}`,
+        })),
+      },
+    ],
+  };
+}
+
+export const tehilimHub: SeoPage = buildTehilimHub();
+export const tehilimIntentionPages: SeoPage[] = INTENTIONS.map(buildIntention);
+/** Hub + intention pages, consumed at runtime by TehilimPage.vue. */
+export const tehilimPages: SeoPage[] = [tehilimHub, ...tehilimIntentionPages];
+
 /** All pages that the prerender script turns into static HTML files. */
-export const allPages: SeoPage[] = [...appPages, ...landingAsSeoPages];
+export const allPages: SeoPage[] = [...appPages, ...landingAsSeoPages, ...tehilimPages];
 
 // ---- Pure HTML transforms (shared by prerender + tests) -----------------
 

--- a/src/content/seoPages.ts
+++ b/src/content/seoPages.ts
@@ -800,6 +800,173 @@ const INTENTIONS: Intention[] = [
       },
     ],
   },
+  {
+    slug: "mariage",
+    title: "Tehilim pour le mariage (zivoug) | Petite Jérusalem",
+    description:
+      "Quels Tehilim lire pour trouver son conjoint (zivoug) : psaumes 32, 38, 70, 71, 121, 124 et 133, à lire seul ou à plusieurs pour aller plus vite.",
+    h1: "Tehilim pour trouver son conjoint (zivoug)",
+    lead: "Le <strong>zivoug</strong> désigne l'âme sœur, le conjoint que l'on cherche à rencontrer. On a coutume de lire certains Tehilim (Psaumes) en priant pour trouver son conjoint et fonder un foyer. Lus à plusieurs, ils se terminent plus vite.",
+    psalms: [32, 38, 70, 71, 121, 124, 133],
+    psalmsNote: "Certains lisent aussi les psaumes 23 et 25, notamment avant et le jour du mariage.",
+    cardTitle: "Mariage (zivoug)",
+    cardDesc: "Les psaumes à lire pour trouver son conjoint et fonder un foyer.",
+    related: ["reussite", "parnassa"],
+    faq: [
+      {
+        q: "Quels Tehilim lire pour trouver son conjoint ?",
+        a: "On lit traditionnellement les psaumes 32, 38, 70, 71, 121, 124 et 133 pour le zivoug. Certains ajoutent les psaumes 23 et 25. En cas de doute, demandez conseil à votre rav.",
+      },
+      {
+        q: "Peut-on lire ces Tehilim à plusieurs ?",
+        a: "Oui. Créez une session de partage de Tehilim, indiquez l'intention (et le prénom concerné), puis partagez le lien : chacun lit quelques psaumes et l'on termine bien plus vite, ensemble.",
+      },
+      {
+        q: "Quand les lire ?",
+        a: "Il n'y a pas de moment imposé ; beaucoup les lisent régulièrement. Les psaumes 23 et 25 sont en particulier lus avant et le jour du mariage.",
+      },
+    ],
+  },
+  {
+    slug: "parnassa",
+    title: "Tehilim pour la parnassa (subsistance) | Petite Jérusalem",
+    description:
+      "Quels Tehilim lire pour la parnassa (subsistance, réussite financière) : psaumes 23, 24 et 32, et la cure de 40 jours (20, 21, 23, 24, 29, 91).",
+    h1: "Tehilim pour la parnassa (subsistance)",
+    lead: "La <strong>parnassa</strong> est la subsistance, ce qui permet de subvenir à ses besoins. On a coutume de lire certains Tehilim (Psaumes) en priant pour une parnassa sereine et une réussite dans son travail.",
+    psalms: [23, 24, 32],
+    psalmsNote:
+      "Il existe aussi une coutume de « cure » sur 40 jours&nbsp;: lire chaque jour les psaumes 20, 21, 23, 24, 29 et 91.",
+    cardTitle: "Parnassa (subsistance)",
+    cardDesc: "Les psaumes à lire pour la subsistance et la réussite financière.",
+    related: ["reussite", "protection"],
+    faq: [
+      {
+        q: "Quels Tehilim lire pour la parnassa ?",
+        a: "On cite souvent les psaumes 23, 24 et 32 pour la parnassa. Une coutume consiste aussi à lire pendant 40 jours les psaumes 20, 21, 23, 24, 29 et 91. En cas de doute, demandez conseil à votre rav.",
+      },
+      {
+        q: "Comment les lire à plusieurs ?",
+        a: "Créez une session de partage de Tehilim, précisez l'intention, partagez le lien : chacun lit ses psaumes et l'on avance ensemble.",
+      },
+      {
+        q: "Qu'est-ce que la cure de 40 jours ?",
+        a: "C'est l'usage de lire chaque jour, pendant 40 jours consécutifs, un ensemble de psaumes (ici 20, 21, 23, 24, 29 et 91) avec une intention particulière.",
+      },
+    ],
+  },
+  {
+    slug: "protection",
+    title: "Tehilim pour la protection | Petite Jérusalem",
+    description:
+      "Quels Tehilim lire pour la protection (danger, voyage, mauvais œil) : psaumes 91, 121, 20, 120, 3 et 34, à lire seul ou à plusieurs.",
+    h1: "Tehilim pour la protection (danger, voyage, mauvais œil)",
+    lead: "On a coutume de lire certains Tehilim (Psaumes) pour demander la <strong>protection</strong> de D.ieu&nbsp;: avant un voyage, en cas de danger, ou contre le mauvais œil (ayin hara).",
+    psalms: [91, 121, 20, 120, 3, 34],
+    psalmsNote:
+      "Contre le mauvais œil (ayin hara), on cite en particulier le psaume 31. Pour un voyage, on récite aussi la Tefilat haderekh (prière du voyageur).",
+    cardTitle: "Protection (danger, voyage)",
+    cardDesc: "Les psaumes à lire pour la protection, le voyage et contre le mauvais œil.",
+    related: ["refoua-chelema", "accouchement"],
+    faq: [
+      {
+        q: "Quels Tehilim lire pour être protégé ?",
+        a: "On cite souvent les psaumes 91, 121, 20, 120, 3 et 34 pour la protection. Contre le mauvais œil, on ajoute le psaume 31. En cas de doute, demandez conseil à votre rav.",
+      },
+      {
+        q: "Quel psaume lire avant un voyage ?",
+        a: "Le psaume 121 est très lu avant un voyage, en plus de la Tefilat haderekh (prière du voyageur).",
+      },
+      {
+        q: "Peut-on les lire à plusieurs ?",
+        a: "Oui. Créez une session de partage de Tehilim, indiquez l'intention et partagez le lien pour lire ensemble.",
+      },
+    ],
+  },
+  {
+    slug: "iloui-nechama",
+    title: "Tehilim pour un défunt (ilouï nechama) | Petite Jérusalem",
+    description:
+      "Quels Tehilim lire pour l'ilouï nechama (à la mémoire d'un défunt) : psaumes 33, 16, 17, 72, 91, 104 et 130, plus le psaume 119 selon le prénom.",
+    h1: "Tehilim à la mémoire d'un défunt (ilouï nechama)",
+    lead: "L'<strong>ilouï nechama</strong> est l'élévation de l'âme d'un défunt. On a coutume de lire des Tehilim (Psaumes) à la mémoire d'un proche, en particulier pour une hiloula (anniversaire de décès). Lus à plusieurs, ils se terminent plus vite.",
+    psalms: [33, 16, 17, 72, 91, 104, 130],
+    psalmsNote:
+      "On lit aussi le psaume 119 (le plus long) en choisissant les sections (huit versets par lettre) qui forment les lettres du prénom du défunt, puis celles du mot נשמה (Nechama).",
+    cardTitle: "Ilouï nechama (mémoire d'un défunt)",
+    cardDesc: "Les psaumes à lire pour l'élévation de l'âme d'un proche disparu.",
+    related: ["refoua-chelema", "protection"],
+    faq: [
+      {
+        q: "Quels Tehilim lire pour un défunt ?",
+        a: "On lit traditionnellement les psaumes 33, 16, 17, 72, 91, 104 et 130 pour un ilouï nechama, ainsi que les sections du psaume 119 correspondant aux lettres du prénom du défunt et au mot נשמה. En cas de doute, demandez conseil à votre rav.",
+      },
+      {
+        q: "Qu'est-ce que le psaume 119 selon le prénom ?",
+        a: "Le psaume 119 est divisé en sections de huit versets, une par lettre de l'alphabet hébraïque. On lit les sections correspondant aux lettres du prénom du défunt, puis celles du mot נשמה (Nechama).",
+      },
+      {
+        q: "Comment organiser une lecture à plusieurs ?",
+        a: "Créez une session de partage de Tehilim à la mémoire du défunt et partagez le lien à la famille et aux proches : chacun lit quelques psaumes, souvent avant la hiloula.",
+      },
+    ],
+  },
+  {
+    slug: "accouchement",
+    title: "Tehilim pour l'accouchement et la grossesse | Petite Jérusalem",
+    description:
+      "Quels Tehilim lire pour la grossesse et l'accouchement : surtout le psaume 20, ainsi que 22, 91 et 1, à lire seul ou à plusieurs.",
+    h1: "Tehilim pour la grossesse et l'accouchement",
+    lead: "On a coutume de lire des Tehilim (Psaumes) pour une grossesse sereine et un accouchement facile, pour la mère comme pour l'enfant à naître.",
+    psalms: [20, 22, 91, 1],
+    psalmsNote:
+      "Le psaume 20 est le plus cité. Une liste élargie attribuée au Rav 'Haïm Kanievsky comprend les psaumes 1 à 4, 21 à 24, 33 à 47, 72 à 86 et 90.",
+    cardTitle: "Grossesse & accouchement",
+    cardDesc: "Les psaumes à lire pour une grossesse et un accouchement sereins.",
+    related: ["refoua-chelema", "protection"],
+    faq: [
+      {
+        q: "Quel Tehilim lire pour un accouchement ?",
+        a: "Le psaume 20 est le plus cité pour l'accouchement ; on lit aussi les psaumes 22, 91 et 1. En cas de doute, demandez conseil à votre rav.",
+      },
+      {
+        q: "Y a-t-il une liste plus longue ?",
+        a: "Oui, une liste élargie attribuée au Rav 'Haïm Kanievsky comprend les psaumes 1 à 4, 21 à 24, 33 à 47, 72 à 86 et 90.",
+      },
+      {
+        q: "Peut-on les lire à plusieurs ?",
+        a: "Oui. La famille et les amis peuvent se répartir les psaumes via une session de partage, pour les terminer ensemble avant l'accouchement.",
+      },
+    ],
+  },
+  {
+    slug: "reussite",
+    title: "Tehilim pour la réussite (hatslakha) | Petite Jérusalem",
+    description:
+      "Quels Tehilim lire pour la réussite (hatslakha) — examen, projet, entreprise : psaumes 4, 20, 32 et 90, à lire seul ou à plusieurs.",
+    h1: "Tehilim pour la réussite (hatslakha)",
+    lead: "La <strong>hatslakha</strong> est la réussite, la bénédiction dans ce que l'on entreprend&nbsp;: un examen, un projet, une nouvelle entreprise. On a coutume de lire des Tehilim (Psaumes) pour la demander.",
+    psalms: [4, 20, 32, 90],
+    psalmsNote:
+      "Cette liste est provisoire et recoupe en partie celle de la <a href=\"/tehilim/parnassa\">parnassa</a> ; elle sera reconfirmée.",
+    cardTitle: "Réussite (hatslakha)",
+    cardDesc: "Les psaumes à lire pour la réussite d'un examen, d'un projet ou d'une entreprise.",
+    related: ["parnassa", "mariage"],
+    faq: [
+      {
+        q: "Quels Tehilim lire pour réussir un examen ou un projet ?",
+        a: "On cite les psaumes 4, 20, 32 et 90 pour la hatslakha (réussite). Cette liste est provisoire et sera reconfirmée. En cas de doute, demandez conseil à votre rav.",
+      },
+      {
+        q: "Quelle différence avec la parnassa ?",
+        a: "La parnassa concerne spécifiquement la subsistance et la réussite financière ; la hatslakha vise la réussite en général. Les listes se recoupent en partie.",
+      },
+      {
+        q: "Peut-on les lire à plusieurs ?",
+        a: "Oui. Créez une session de partage de Tehilim, précisez l'intention et partagez le lien pour lire ensemble.",
+      },
+    ],
+  },
 ];
 
 const intentionBySlug = new Map(INTENTIONS.map((i) => [i.slug, i]));

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -61,6 +61,7 @@ const en: LocaleMessages = {
     discover: "Discover",
     finishChass: "Finish the Shas",
     shareTehilim: "Share Tehilim",
+    tehilimIntentions: "Tehilim by intention",
   },
   home: {
     heroTitle: "Your digital spiritual center",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -59,6 +59,7 @@ const fr = {
     discover: "Découvrir",
     finishChass: "Finir le Chass",
     shareTehilim: "Partage de Tehilim",
+    tehilimIntentions: "Tehilim par intention",
   },
   home: {
     heroTitle: "Étudier et partager la Torah, à plusieurs",

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -61,6 +61,7 @@ const he: LocaleMessages = {
     discover: "גלה",
     finishChass: "לסיים את הש״ס",
     shareTehilim: "חלוקת תהילים",
+    tehilimIntentions: "תהילים לפי כוונה",
   },
   home: {
     heroTitle: "המרכז הרוחני הדיגיטלי שלכם",

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -12,6 +12,7 @@ import NotFound from "../views/NotFound.vue";
 import TextReadingPage from "../views/TextReading/TextReadingPage.vue";
 import StudyPage from "../views/StudyPage.vue";
 import ContentPage from "../views/ContentPage.vue";
+import TehilimPage from "../views/TehilimPage.vue";
 
 export default [
   {
@@ -90,6 +91,18 @@ export default [
     path: "/partage-tehilim",
     name: "partage-tehilim",
     component: ContentPage,
+  },
+  // Tehilim par intention: hub + intention pages, rendered from
+  // src/content/seoPages.ts (same markup the prerender step serves to crawlers).
+  {
+    path: "/tehilim",
+    name: "tehilim-hub",
+    component: TehilimPage,
+  },
+  {
+    path: "/tehilim/:slug",
+    name: "tehilim-intention",
+    component: TehilimPage,
   },
   {
     path: "/:pathMatch(.*)*",

--- a/src/views/TehilimPage.vue
+++ b/src/views/TehilimPage.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+/**
+ * Renders the "Tehilim par intention" hub (/tehilim) and the intention pages
+ * (/tehilim/:slug) from the shared `src/content/seoPages.ts` content, so a human
+ * visitor sees the same markup the prerender step serves to crawlers. These
+ * pages are French-only for now (the brief defers i18n).
+ */
+import { computed, onMounted, watch } from "vue";
+import { useRoute } from "vue-router";
+import { tehilimPages, SITE_URL } from "../content/seoPages";
+import { seoService } from "../services/seoService";
+
+const route = useRoute();
+
+const page = computed(() => tehilimPages.find((p) => p.path === route.path) ?? null);
+
+function applyMeta() {
+  const p = page.value;
+  if (!p) return;
+  const url = `${SITE_URL}${p.path}`;
+  seoService.setMeta({
+    title: p.title,
+    description: p.description,
+    canonical: url,
+    og: { url, type: "article" },
+  });
+}
+
+onMounted(applyMeta);
+watch([() => route.path], applyMeta);
+</script>
+
+<template>
+  <div v-if="page" class="seo-page" v-html="page.bodyHtml"></div>
+  <main v-else class="seo-article">
+    <h1>Intention introuvable</h1>
+    <p>
+      Cette intention n'existe pas (encore).
+      <a href="/tehilim">Voir toutes les intentions « Tehilim par intention »</a>.
+    </p>
+  </main>
+</template>


### PR DESCRIPTION
## Objectif

Suite de #82 : décline le gabarit validé aux **6 autres intentions** du brief (§4). Le hub `/tehilim` liste désormais les 7 intentions et elles se lient entre elles.

> ⚠️ **Empilée sur #82** (branche `feat/seo-tehilim-hub-refoua`). À fusionner **après** #82 — une fois #82 mergée, le diff de cette PR contre `main` ne contiendra plus que les 6 pages ci-dessous.

## Pages ajoutées (pré-rendues)

| URL | Intention | Psaumes (selon le brief) |
|-----|-----------|--------------------------|
| `/tehilim/mariage` | Trouver son conjoint (zivoug) | 32, 38, 70, 71, 121, 124, 133 |
| `/tehilim/parnassa` | Subsistance | 23, 24, 32 (+ cure 40 j : 20, 21, 23, 24, 29, 91) |
| `/tehilim/protection` | Danger, voyage, mauvais œil | 91, 121, 20, 120, 3, 34 |
| `/tehilim/iloui-nechama` | Mémoire d'un défunt | 33, 16, 17, 72, 91, 104, 130 (+ Ps. 119 selon le prénom + נשמה) |
| `/tehilim/accouchement` | Grossesse & accouchement | 20, 22, 91, 1 |
| `/tehilim/reussite` | Hatslakha | 4, 20, 32, 90 *(provisoire, à reconfirmer)* |

Chaque page reprend le gabarit de #82 : H1, intro, CTA en haut, psaumes liés au lecteur (`/lire/{102+N}`), « Comment partager », **FAQ** (→ JSON-LD `FAQPage`), `BreadcrumbList`, maillage interne (hub + 2 intentions liées + `/partage-tehilim` + `/etude`) et **avertissement prudent** (« demandez conseil à votre rav »).

## Maillage & technique
- Le hub liste automatiquement les 7 intentions (cartes + `ItemList` JSON-LD).
- Sitemap (14 URLs) et IndexNow alimentés depuis la même source.
- Aucune nouvelle dépendance ni nouvelle « tuyauterie » : seules des données ajoutées au tableau `INTENTIONS`.

## À revalider par une personne compétente (brief §4 & §7)
Les listes de psaumes sont **indicatives**. La page `reussite` en particulier est **provisoire**. Chaque page le mentionne explicitement.

## Tests
`type-check` ✅ · `vitest run` ✅ (77) · `lint` ✅ · `build` ✅ (15 pages prérendues, sitemap à 14 URLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7R31bhFs9JgLqs1DKPq7W)_