### PR TITLE
feat(share): message d'invitation pré-rempli, adapté au type de session

### DIFF
--- a/src/components/ShareModal.vue
+++ b/src/components/ShareModal.vue
@@ -8,6 +8,8 @@ interface Props {
   show: boolean;
   sessionName: string;
   shareUrl: string;
+  /** Session text type (e.g. "Tehilim") used to tailor the pre-filled invite. */
+  sessionType?: string;
 }
 
 interface Emits {
@@ -79,15 +81,24 @@ const generateQRCode = async () => {
   }
 };
 
+/**
+ * Build the pre-filled invite text. Tehilim sessions get a "chaîne de Tehilim"
+ * wording (the #1 acquisition channel is WhatsApp), others a generic study one.
+ * The session name usually already carries the intention (e.g. "… refoua
+ * chelema de …"), so we interpolate it into the message.
+ */
+const buildShareMessage = () => {
+  const key = props.sessionType === "Tehilim" ? "shareModal.inviteTehilim" : "shareModal.inviteStudy";
+  return `${t(key, { name: props.sessionName })}\n\n${props.shareUrl}`;
+};
+
 const shareToWhatsApp = () => {
-  const message = `${t("shareModal.shareMessage")}: ${props.sessionName}\n\n${props.shareUrl}`;
-  const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(message)}`;
+  const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(buildShareMessage())}`;
   window.open(whatsappUrl, "_blank");
 };
 
 const shareToSMS = () => {
-  const message = `${t("shareModal.shareMessage")}: ${props.sessionName}\n\n${props.shareUrl}`;
-  const smsUrl = `sms:?body=${encodeURIComponent(message)}`;
+  const smsUrl = `sms:?body=${encodeURIComponent(buildShareMessage())}`;
   window.location.href = smsUrl;
 };
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -260,7 +260,9 @@ const en: LocaleMessages = {
     scanQR: "Or scan the QR code",
     scanQRDesc: "Scan this code to access the session directly",
     qrError: "Error generating QR code",
-    shareMessage: "Join me for a shared study session",
+    inviteTehilim:
+      "Join the Tehilim chain « {name} » 📖 Everyone reads a few psalms and we finish together. Reserve yours here:",
+    inviteStudy: "Join the shared study « {name} » 📖 Reserve your passages and let's learn together:",
   },
   batchSelection: {
     textsSelected: "{count} texts selected",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -261,7 +261,10 @@ const fr = {
     scanQR: "Ou scanner le QR code",
     scanQRDesc: "Scannez ce code pour accéder directement à la session",
     qrError: "Erreur lors de la génération du QR code",
-    shareMessage: "Rejoignez-moi pour une session d'étude partagée",
+    inviteTehilim:
+      "Rejoignez la chaîne de Tehilim « {name} » 📖 Chacun lit quelques psaumes et l'on termine ensemble. Réservez les vôtres ici :",
+    inviteStudy:
+      "Rejoignez l'étude partagée « {name} » 📖 Réservez vos passages et étudions ensemble :",
   },
   batchSelection: {
     textsSelected: "{count} textes sélectionnés",

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -259,7 +259,9 @@ const he: LocaleMessages = {
     scanQR: "או סרוק את קוד ה-QR",
     scanQRDesc: "סרוק קוד זה כדי לגשת ישירות לסשן",
     qrError: "שגיאה ביצירת קוד QR",
-    shareMessage: "הצטרף אליי לסשן לימוד משותף",
+    inviteTehilim:
+      "הצטרפו לשרשרת התהילים « {name} » 📖 כל אחד קורא כמה פרקים ומסיימים יחד. הזמינו את שלכם כאן:",
+    inviteStudy: "הצטרפו ללימוד המשותף « {name} » 📖 הזמינו את הקטעים שלכם ונלמד יחד:",
   },
   batchSelection: {
     textsSelected: "{count} טקסטים נבחרו",

--- a/src/views/ProfilePage.vue
+++ b/src/views/ProfilePage.vue
@@ -327,6 +327,7 @@ onMounted(async () => {
       v-model:show="showShareModal"
       :session-name="selectedSession?.name || ''"
       :share-url="shareUrl"
+      :session-type="selectedSession?.type"
     />
 
     <EditSessionModal

--- a/src/views/ShareReading/DetailSession.vue
+++ b/src/views/ShareReading/DetailSession.vue
@@ -519,6 +519,7 @@ watch(session, (s) => applySessionSeo(s));
       v-model:show="showShareModal"
       :session-name="session?.name || ''"
       :share-url="shareUrl"
+      :session-type="session?.type"
     />
   </main>
 </template>


### PR DESCRIPTION
## Objectif

Quick-win partage du brief SEO (§5.2). WhatsApp étant le **canal d'acquisition n°1**, on rend le message pré-rempli plus engageant et adapté.

> ℹ️ Le **QR code** demandé au §5.2 **existe déjà** dans le module de partage (`ShareModal.vue`). Cette PR complète donc le volet « message pré-rempli ». L'**image OG par session** fait l'objet d'une PR distincte.

## Avant / après

**Avant** — une seule ligne générique :
> Rejoignez-moi pour une session d'étude partagée: «Nom»

**Après** — adapté au type de session, avec le nom interpolé :
- Tehilim → « Rejoignez la chaîne de Tehilim « {name} » 📖 Chacun lit quelques psaumes et l'on termine ensemble. Réservez les vôtres ici : »
- Autres → « Rejoignez l'étude partagée « {name} » 📖 Réservez vos passages et étudions ensemble : »

Le nom de session porte généralement déjà l'intention (« … refoua chelema de … »), donc l'invitation devient naturellement contextuelle.

## Changements
- `ShareModal.vue` : prop optionnelle `sessionType` + helper `buildShareMessage()` (utilisé par WhatsApp **et** SMS).
- i18n : nouvelles clés `shareModal.inviteTehilim` / `inviteStudy` (fr/en/he) en remplacement de `shareMessage`.
- `DetailSession.vue` et `ProfilePage.vue` passent `:session-type="session?.type"`.

## Tests
`type-check` ✅ · `vitest run` ✅ (71) · `lint` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7R31bhFs9JgLqs1DKPq7W)_