### PR TITLE
feat(seo): pages de psaumes individuels (/etude/tehilim/N) — phase 2

### DIFF
--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -25,7 +25,7 @@
  * environment-agnostic module) so the Vue app and this build step share one
  * source of truth. It is a TypeScript file, loaded here through `jiti`.
  */
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createJiti } from "jiti";
@@ -36,6 +36,47 @@ const jiti = createJiti(import.meta.url);
 const { allPages, renderPage, buildSitemap, SITE_URL } = await jiti.import(
   "../src/content/seoPages.ts",
 );
+const {
+  TEHILIM_CHAPTER_COUNT,
+  chapterPath,
+  chapterTitle,
+  chapterDescription,
+  buildChapterBody,
+  chapterJsonLd,
+} = await jiti.import("../src/content/tehilimChapter.ts");
+
+/**
+ * Generate the individual Tehilim chapter pages (/etude/tehilim/N) from the
+ * local text file. Returns their sitemap entries so they can be appended to
+ * sitemap.xml. Kept out of `allPages` so the full Hebrew text never lands in
+ * the SPA bundle.
+ */
+function generateTehilimChapters(dist, template) {
+  const text = JSON.parse(readFileSync(join(dist, "texts", "tehilim.json"), "utf-8"));
+  const dir = join(dist, "etude", "tehilim");
+  mkdirSync(dir, { recursive: true });
+
+  const entries = [];
+  for (let n = 1; n <= TEHILIM_CHAPTER_COUNT; n++) {
+    const verses = text[String(n)]?.he;
+    if (!verses) {
+      console.warn(`[prerender-seo] Tehilim ${n} missing from tehilim.json, skipped.`);
+      continue;
+    }
+    const page = {
+      file: `etude/tehilim/${n}.html`,
+      path: chapterPath(n),
+      title: chapterTitle(n),
+      description: chapterDescription(n),
+      bodyHtml: buildChapterBody(n, verses),
+      jsonLd: chapterJsonLd(n),
+    };
+    writeFileSync(join(dist, page.file), renderPage(template, page), "utf-8");
+    entries.push({ path: page.path, priority: 0.5, changefreq: "yearly" });
+  }
+  console.log(`[prerender-seo] Generated ${entries.length} Tehilim chapter page(s).`);
+  return entries;
+}
 
 function main() {
   const dist = join(__dirname, "..", "dist");
@@ -51,11 +92,16 @@ function main() {
     console.log(`[prerender-seo] ${page.path} -> dist/${page.file}`);
   }
 
-  // 3. Sitemap, regenerated from the same list so it can never drift.
-  const lastmod = new Date().toISOString().slice(0, 10);
-  writeFileSync(join(dist, "sitemap.xml"), buildSitemap(lastmod), "utf-8");
+  // 2b. Individual Tehilim chapter pages (long-tail SEO), generated from the
+  //     text file and added to the sitemap below.
+  const chapterEntries = generateTehilimChapters(dist, template);
 
-  console.log(`[prerender-seo] Generated ${allPages.length} page(s) + app.html + sitemap.xml.`);
+  // 3. Sitemap, regenerated from the same lists so it can never drift.
+  const lastmod = new Date().toISOString().slice(0, 10);
+  writeFileSync(join(dist, "sitemap.xml"), buildSitemap(lastmod, chapterEntries), "utf-8");
+
+  const total = allPages.length + chapterEntries.length;
+  console.log(`[prerender-seo] Generated ${total} page(s) + app.html + sitemap.xml.`);
   console.log(`[prerender-seo] Canonical host: ${SITE_URL}`);
 }
 

--- a/src/__tests__/tehilimChapter.test.ts
+++ b/src/__tests__/tehilimChapter.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  TEHILIM_CHAPTER_COUNT,
+  chapterPath,
+  chapterTitle,
+  chapterDescription,
+  isValidChapter,
+  buildChapterBody,
+  chapterJsonLd,
+} from "../content/tehilimChapter";
+
+describe("tehilimChapter", () => {
+  it("valide les bornes de chapitre 1..150", () => {
+    expect(TEHILIM_CHAPTER_COUNT).toBe(150);
+    expect(isValidChapter(1)).toBe(true);
+    expect(isValidChapter(150)).toBe(true);
+    expect(isValidChapter(0)).toBe(false);
+    expect(isValidChapter(151)).toBe(false);
+    expect(isValidChapter(1.5)).toBe(false);
+  });
+
+  it("construit des URLs et métadonnées contenant le numéro", () => {
+    expect(chapterPath(121)).toBe("/etude/tehilim/121");
+    expect(chapterTitle(121)).toContain("Tehilim 121");
+    expect(chapterTitle(121).toLowerCase()).toContain("phonétique");
+    expect(chapterDescription(121)).toContain("121");
+  });
+
+  it("rend l'hébreu, la phonétique, la navigation et le CTA", () => {
+    const body = buildChapterBody(121, ["שִׁיר לַמַּעֲלוֹת אֶשָּׂא עֵינַי"]);
+    expect(body).toContain('class="he"');
+    expect(body).toContain('class="tl"');
+    expect(body).toContain('href="/share-reading/new-session"');
+    expect(body).toContain('href="/etude/tehilim/120"'); // prev
+    expect(body).toContain('href="/etude/tehilim/122"'); // next
+  });
+
+  it("n'affiche pas de lien précédent au chapitre 1 ni suivant au 150", () => {
+    expect(buildChapterBody(1, ["x"])).not.toContain("/etude/tehilim/0");
+    expect(buildChapterBody(150, ["x"])).not.toContain("/etude/tehilim/151");
+  });
+
+  it("échappe le HTML et nettoie les marqueurs éditoriaux", () => {
+    const body = buildChapterBody(1, ["שָׁלוֹם {פ}", "a &thinsp; b <x>"]);
+    expect(body).not.toContain("{פ}");
+    expect(body).not.toContain("<x>");
+    expect(body).toContain("&lt;x&gt;");
+  });
+
+  it("émet un BreadcrumbList et un CreativeWork", () => {
+    const types = chapterJsonLd(121).map((o) => o["@type"]);
+    expect(types).toContain("BreadcrumbList");
+    expect(types).toContain("CreativeWork");
+  });
+});

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -219,3 +219,61 @@ button,
 .seo-footer a {
   color: var(--color-primary);
 }
+
+/* Individual Tehilim chapter pages (/etude/tehilim/N): Hebrew verse + phonetic. */
+.seo-article .seo-note {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.tehilim-chapter .tehilim-verses {
+  list-style: none;
+  margin-inline-start: 0;
+}
+
+.tehilim-chapter .tehilim-verses li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+:root.dark .tehilim-chapter .tehilim-verses li {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.tehilim-chapter .verse-num {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.tehilim-chapter .he {
+  font-family: var(--font-hebrew);
+  font-size: 1.6rem;
+  line-height: 2;
+  direction: rtl;
+}
+
+.tehilim-chapter .tl {
+  color: var(--color-text-secondary);
+  font-style: italic;
+  line-height: 1.6;
+}
+
+:root.dark .tehilim-chapter .tl {
+  color: #cbd5e1;
+}
+
+.tehilim-chapter .tehilim-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.tehilim-chapter .tehilim-nav a {
+  color: var(--color-primary);
+  font-weight: 600;
+}

--- a/src/content/seoPages.ts
+++ b/src/content/seoPages.ts
@@ -239,7 +239,7 @@ export const appPages: SeoPage[] = [
     <section class="seo-section">
       <h2>Les textes disponibles</h2>
       <ul>
-        <li><strong>Tehilim</strong> (Psaumes) : les 150 chapitres du livre de Tehilim.</li>
+        <li><strong>Tehilim</strong> (Psaumes) : les <a href="/etude/tehilim/1">150 chapitres</a> du livre de Tehilim, en hébreu et en phonétique.</li>
         <li><strong>Michna</strong> : les six ordres (sedarim) de la Michna.</li>
         <li><strong>Talmud Bavli</strong> : les traités (massekhtot) du Talmud de Babylone.</li>
         <li><strong>Tanakh</strong> : la Torah, les Neviim (Prophètes) et les Ketouvim (Écrits).</li>
@@ -801,21 +801,32 @@ export function renderPage(template: string, page: SeoPage): string {
   return injectBody(injectMeta(template, page), page);
 }
 
-/** Build sitemap.xml from the indexable pages. `lastmod` is an ISO date string. */
-export function buildSitemap(lastmod: string): string {
-  const urls = allPages
+export type SitemapEntry = { path: string; priority: number; changefreq: string };
+
+/**
+ * Build sitemap.xml from the indexable pages, plus any `extra` URLs (e.g. the
+ * 150 Tehilim chapter pages, which are generated outside `allPages` to keep the
+ * SPA bundle small). `lastmod` is an ISO date string.
+ */
+export function buildSitemap(lastmod: string, extra: SitemapEntry[] = []): string {
+  const fromPages: SitemapEntry[] = allPages
     .filter((p) => p.sitemap !== false)
     .map((p) => {
       const s = p.sitemap || { priority: 0.5, changefreq: "weekly" };
-      return [
+      return { path: p.path, priority: s.priority, changefreq: s.changefreq };
+    });
+
+  const urls = [...fromPages, ...extra]
+    .map((s) =>
+      [
         "  <url>",
-        `    <loc>${SITE_URL}${p.path === "/" ? "/" : p.path}</loc>`,
+        `    <loc>${SITE_URL}${s.path === "/" ? "/" : s.path}</loc>`,
         `    <lastmod>${lastmod}</lastmod>`,
         `    <changefreq>${s.changefreq}</changefreq>`,
         `    <priority>${s.priority.toFixed(1)}</priority>`,
         "  </url>",
-      ].join("\n");
-    })
+      ].join("\n"),
+    )
     .join("\n");
 
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;

--- a/src/content/tehilimChapter.ts
+++ b/src/content/tehilimChapter.ts
@@ -1,0 +1,140 @@
+/**
+ * Content for the individual Tehilim (Psalm) pages, e.g. /etude/tehilim/121.
+ *
+ * These long-tail SEO pages show a chapter's full Hebrew text plus a French
+ * phonetic transliteration ("tehilim 121 en phonétique / en français" is a very
+ * searched query). The body markup is built here so it is shared by BOTH:
+ *  - `scripts/prerender-seo.mjs` (build time, verses read from the JSON file),
+ *  - `src/views/TehilimChapterPage.vue` (runtime, verses fetched from
+ *    `/texts/tehilim.json`).
+ * so a crawler and a human visitor get identical content.
+ *
+ * Keep this module free of browser- or Node-only APIs: the big text file is
+ * passed in by the caller, never imported here, so it never lands in the SPA
+ * bundle.
+ */
+import { transliterate } from "../services/hebrewTransliteration";
+
+const SITE_URL = "https://petite-jerusalem.fr";
+const SITE_NAME = "Petite Jérusalem";
+
+export const TEHILIM_CHAPTER_COUNT = 150;
+
+/** Reader URL for the full chapter (Tehilim N is textId 102 + N). */
+const readerHref = (n: number): string => `/lire/${102 + n}`;
+
+export const chapterPath = (n: number): string => `/etude/tehilim/${n}`;
+
+export const isValidChapter = (n: number): boolean =>
+  Number.isInteger(n) && n >= 1 && n <= TEHILIM_CHAPTER_COUNT;
+
+export const chapterTitle = (n: number): string =>
+  `Tehilim ${n} en phonétique et en hébreu (Psaume ${n}) | ${SITE_NAME}`;
+
+export const chapterDescription = (n: number): string =>
+  `Lisez le Tehilim ${n} (Psaume ${n}) en hébreu avec sa phonétique pour le lire facilement. ` +
+  `Texte intégral, navigation chapitre par chapitre et partage de la lecture à plusieurs.`;
+
+/** Strip editorial markers / entities so the verse is clean for display + transliteration. */
+function cleanVerse(raw: string): string {
+  return raw
+    .replace(/&thinsp;|&nbsp;/g, " ")
+    .replace(/\{[^}]*\}/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Escape text for safe inclusion in HTML (verses contain no markup of their own). */
+function esc(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function versesHtml(verses: string[]): string {
+  return verses
+    .map((raw, i) => {
+      const he = cleanVerse(raw);
+      const tl = transliterate(he);
+      return (
+        `<li>\n` +
+        `        <span class="verse-num">${i + 1}</span>\n` +
+        `        <span class="he" lang="he" dir="rtl">${esc(he)}</span>\n` +
+        `        <span class="tl" lang="fr">${esc(tl)}</span>\n` +
+        `      </li>`
+      );
+    })
+    .join("\n      ");
+}
+
+/** Build the crawlable body for a chapter page. `verses` is the chapter's `he` array. */
+export function buildChapterBody(n: number, verses: string[]): string {
+  const prev =
+    n > 1
+      ? `<a class="prev" href="${chapterPath(n - 1)}">← Tehilim ${n - 1}</a>`
+      : `<span></span>`;
+  const next =
+    n < TEHILIM_CHAPTER_COUNT
+      ? `<a class="next" href="${chapterPath(n + 1)}">Tehilim ${n + 1} →</a>`
+      : `<span></span>`;
+
+  return `
+  <main class="seo-article tehilim-chapter">
+    <h1>Tehilim ${n} — Psaume ${n}</h1>
+    <p class="seo-lead">
+      Le texte intégral du Tehilim ${n} (Psaume ${n}) en hébreu, accompagné de la phonétique
+      pour le lire même sans maîtriser l'hébreu. Lisez-le seul ou partagez-en la lecture à plusieurs.
+    </p>
+
+    <p><a class="seo-cta" href="/share-reading/new-session">Partager la lecture des Tehilim</a></p>
+
+    <section class="seo-section">
+      <ol class="tehilim-verses">
+      ${versesHtml(verses)}
+      </ol>
+      <p class="seo-note">
+        <em>Phonétique générée automatiquement comme aide à la lecture&nbsp;; elle peut comporter
+        des approximations. La traduction française sera ajoutée prochainement.</em>
+      </p>
+    </section>
+
+    <nav class="tehilim-nav" aria-label="Navigation entre les psaumes">
+      ${prev}
+      ${next}
+    </nav>
+
+    <section class="seo-section">
+      <h2>Aller plus loin</h2>
+      <ul>
+        <li><a href="${readerHref(n)}">Lire le Tehilim ${n} dans le lecteur</a></li>
+        <li><a href="/partage-tehilim">Partager les Tehilim à plusieurs</a></li>
+        <li><a href="/etude">Étude libre des textes</a></li>
+      </ul>
+    </section>
+  </main>`;
+}
+
+/** schema.org JSON-LD for a chapter page (breadcrumb + the text as CreativeWork). */
+export function chapterJsonLd(n: number): Record<string, unknown>[] {
+  const path = chapterPath(n);
+  return [
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Accueil", item: `${SITE_URL}/` },
+        { "@type": "ListItem", position: 2, name: "Étude", item: `${SITE_URL}/etude` },
+        { "@type": "ListItem", position: 3, name: `Tehilim ${n}`, item: `${SITE_URL}${path}` },
+      ],
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "CreativeWork",
+      name: `Tehilim ${n} (Psaume ${n})`,
+      inLanguage: ["he", "fr"],
+      isPartOf: { "@type": "CreativeWork", name: "Tehilim (Psaumes)" },
+      url: `${SITE_URL}${path}`,
+    },
+  ];
+}

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -12,6 +12,7 @@ import NotFound from "../views/NotFound.vue";
 import TextReadingPage from "../views/TextReading/TextReadingPage.vue";
 import StudyPage from "../views/StudyPage.vue";
 import ContentPage from "../views/ContentPage.vue";
+import TehilimChapterPage from "../views/TehilimChapterPage.vue";
 
 export default [
   {
@@ -53,6 +54,13 @@ export default [
     path: "/etude",
     name: "study",
     component: StudyPage,
+  },
+  // Individual Tehilim chapter pages (long-tail SEO), prerendered to static
+  // HTML and rendered at runtime from src/content/tehilimChapter.ts.
+  {
+    path: "/etude/tehilim/:chapter",
+    name: "tehilim-chapter",
+    component: TehilimChapterPage,
   },
   {
     path: "/chiourim",

--- a/src/views/TehilimChapterPage.vue
+++ b/src/views/TehilimChapterPage.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+/**
+ * Individual Tehilim chapter page (/etude/tehilim/:chapter).
+ *
+ * Renders the same body markup the prerender step bakes into the static file,
+ * by fetching `/texts/tehilim.json` at runtime and calling the shared
+ * `buildChapterBody`. The big text file is fetched (and cached in-module), so it
+ * never lands in the SPA bundle.
+ */
+import { computed, onMounted, ref, watch } from "vue";
+import { useRoute } from "vue-router";
+import {
+  buildChapterBody,
+  chapterPath,
+  chapterTitle,
+  chapterDescription,
+  isValidChapter,
+} from "../content/tehilimChapter";
+import { seoService } from "../services/seoService";
+
+const SITE_URL = "https://petite-jerusalem.fr";
+
+type TehilimData = Record<string, { he: string[] }>;
+let cache: Promise<TehilimData> | null = null;
+function loadTehilim(): Promise<TehilimData> {
+  if (!cache) cache = fetch("/texts/tehilim.json").then((r) => r.json() as Promise<TehilimData>);
+  return cache;
+}
+
+const route = useRoute();
+const verses = ref<string[] | null>(null);
+const loaded = ref(false);
+
+const chapter = computed(() => Number(route.params.chapter));
+const valid = computed(() => isValidChapter(chapter.value));
+
+const bodyHtml = computed(() =>
+  valid.value && verses.value ? buildChapterBody(chapter.value, verses.value) : "",
+);
+
+async function load() {
+  loaded.value = false;
+  verses.value = null;
+  if (!valid.value) {
+    loaded.value = true;
+    return;
+  }
+  try {
+    const data = await loadTehilim();
+    verses.value = data[String(chapter.value)]?.he ?? null;
+  } catch {
+    verses.value = null;
+  }
+  loaded.value = true;
+  applyMeta();
+}
+
+function applyMeta() {
+  if (!valid.value) return;
+  const url = `${SITE_URL}${chapterPath(chapter.value)}`;
+  seoService.setMeta({
+    title: chapterTitle(chapter.value),
+    description: chapterDescription(chapter.value),
+    canonical: url,
+    og: { url, type: "article" },
+  });
+}
+
+onMounted(load);
+watch(() => route.params.chapter, load);
+</script>
+
+<template>
+  <div v-if="bodyHtml" class="seo-page" v-html="bodyHtml"></div>
+  <main v-else-if="loaded" class="seo-article">
+    <h1>Tehilim introuvable</h1>
+    <p>
+      Ce psaume n'existe pas (les Tehilim vont de 1 à 150).
+      <a href="/etude/tehilim/1">Commencer au Tehilim 1</a>.
+    </p>
+  </main>
+</template>


### PR DESCRIPTION
## Objectif

Phase 2 du brief (§6) : **150 pages de psaumes individuels** `/etude/tehilim/1` … `/etude/tehilim/150`, pour la longue traîne (« tehilim 121 en phonétique / en français », très demandée).

## Contenu de chaque page (pré-rendue)
- **H1** « Tehilim N — Psaume N » + intro.
- **CTA** de partage.
- **Texte intégral en hébreu** (depuis `public/texts/tehilim.json`) + **phonétique française** générée via le service `hebrewTransliteration` existant (ex. Ps. 121:1 → *« chir lamaalot esa éna el-heharim méayin yavo ezri »*).
- **Navigation précédent / suivant** (chaîne crawlable des 150 chapitres).
- Liens vers le lecteur complet, `/partage-tehilim`, `/etude`.
- JSON-LD `BreadcrumbList` + `CreativeWork`.

## Architecture (sans alourdir le bundle SPA)
- **`src/content/tehilimChapter.ts`** : constructeur partagé du corps/métadonnées/JSON-LD. **Le gros fichier texte n'est jamais importé** dans ce module — il est passé en argument. Résultat vérifié : le bundle JS reste à ~1 Mo et `tehilim.json` (370 Ko) **n'y est pas inliné**.
- **`TehilimChapterPage.vue`** (route `/etude/tehilim/:chapter`) récupère `/texts/tehilim.json` au runtime et rend exactement le même markup que la version pré-rendue (parité humain/crawler).
- **`prerender-seo.mjs`** génère les 150 fichiers statiques (`dist/etude/tehilim/N.html`) et les ajoute au **sitemap** ; `buildSitemap` accepte désormais des URLs supplémentaires. `/etude` pointe vers la série.

## Vérification
- `type-check` ✅ · `vitest run` ✅ (77, dont 6 nouveaux) · `lint` ✅
- `build` ✅ : **150 pages générées**, sitemap à **156 URLs**, contenu hébreu + phonétique présent dans le HTML brut, texte **absent** du bundle JS.

## Note (brief §6 & §7)
La **traduction française** des Tehilim n'est pas dans le dépôt : les pages livrent donc **hébreu + phonétique** dès maintenant (vraie page, non « mince »), avec une mention indiquant que la traduction suivra (« étoffe ensuite »). À envisager ensuite : relier ces pages depuis le hub `/tehilim` et les pages d'intention (PR #82/#83) — actuellement celles-ci pointent vers le lecteur ; on pourra les faire pointer vers `/etude/tehilim/N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7R31bhFs9JgLqs1DKPq7W)_