### PR TITLE
content: enlever les formulations hésitantes / disclaimers sur la qualité

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -225,11 +225,6 @@ button,
   border-color: rgba(255, 255, 255, 0.1);
 }
 
-.seo-article .seo-note {
-  font-size: 0.9rem;
-  color: var(--color-text-secondary);
-}
-
 /* "Tehilim par intention" hub: simple list of intentions (whole row is a link). */
 .seo-article .tehilim-list {
   list-style: none;

--- a/src/content/etudeTexts.ts
+++ b/src/content/etudeTexts.ts
@@ -150,13 +150,9 @@ function sectionTextHtml(section: TextSection, numbered: boolean): string {
   return `<ol class="reading-lines">\n      ${linesHtml(section.he, numbered)}\n      </ol>`;
 }
 
-const READING_DISCLAIMER =
-  "Phonétique générée automatiquement comme aide à la lecture (approximative). Texte hébreu d'après le jeu de données public Sefaria.";
-
-/** Short SEO sentences reused by the prerender AND the live reader (top/bottom). */
+/** Short SEO intro reused by the prerender AND the live reader (top of page). */
 export const READING_LEAD =
   "Texte intégral en hébreu, accompagné de la phonétique pour le lire même sans maîtriser l'hébreu. Lisez-le seul ou partagez-en la lecture à plusieurs.";
-export const READING_NOTE = READING_DISCLAIMER;
 
 /** A short human title for a section, used in H1 / breadcrumbs. */
 export function sectionHeading(entry: TextStudyJsonEntry, section: TextSection): string {
@@ -260,7 +256,6 @@ export function buildSectionBody(
 
     <section class="seo-section">
       ${sectionTextHtml(section, numbered)}
-      <p class="seo-note"><em>${READING_DISCLAIMER}</em></p>
     </section>
 
     <nav class="reading-nav" aria-label="Navigation">

--- a/src/content/seoPages.ts
+++ b/src/content/seoPages.ts
@@ -763,10 +763,6 @@ type Intention = {
   faq: { q: string; a: string }[];
 };
 
-/** Prudent disclaimer shown on every intention page (lists pending revalidation). */
-const TEHILIM_DISCLAIMER =
-  "Ces listes sont indicatives, selon les sources couramment citées. En cas de doute, demandez conseil à votre rav.";
-
 const INTENTIONS: Intention[] = [
   {
     slug: "refoua-chelema",
@@ -942,13 +938,13 @@ const INTENTIONS: Intention[] = [
     lead: "La <strong>hatslakha</strong> est la réussite, la bénédiction dans ce que l'on entreprend&nbsp;: un examen, un projet, une nouvelle entreprise. On a coutume de lire des Tehilim (Psaumes) pour la demander.",
     psalms: [4, 20, 32, 90],
     psalmsNote:
-      "Cette liste est provisoire et recoupe en partie celle de la <a href=\"/tehilim/parnassa\">parnassa</a> ; elle sera reconfirmée.",
+      "Plusieurs de ces psaumes rejoignent ceux que l'on lit pour la <a href=\"/tehilim/parnassa\">parnassa</a>.",
     cardTitle: "Réussite (hatslakha)",
     cardDesc: "Les psaumes à lire pour la réussite d'un examen, d'un projet ou d'une entreprise.",    related: ["parnassa", "mariage"],
     faq: [
       {
         q: "Quels Tehilim lire pour réussir un examen ou un projet ?",
-        a: "On cite les psaumes 4, 20, 32 et 90 pour la hatslakha (réussite). Cette liste est provisoire et sera reconfirmée. En cas de doute, demandez conseil à votre rav.",
+        a: "On cite les psaumes 4, 20, 32 et 90 pour la hatslakha (réussite). En cas de doute, demandez conseil à votre rav.",
       },
       {
         q: "Quelle différence avec la parnassa ?",
@@ -992,7 +988,6 @@ function buildIntention(it: Intention): SeoPage {
         ${psalmsList}
       </ul>
       ${it.psalmsNote ? `<p>${it.psalmsNote}</p>` : ""}
-      <p class="seo-note"><em>${TEHILIM_DISCLAIMER}</em></p>
     </section>
 
     <section class="seo-section">
@@ -1074,7 +1069,6 @@ function buildTehilimHub(): SeoPage {
         <a href="/partage-tehilim">partager les Tehilim à plusieurs</a> ou lancez directement une
         <a href="${SHARE_NEW_SESSION}">session de partage</a>.
       </p>
-      <p class="seo-note"><em>${TEHILIM_DISCLAIMER}</em></p>
     </section>
   </main>`;
 

--- a/src/views/TextReading/TextReadingPage.vue
+++ b/src/views/TextReading/TextReadingPage.vue
@@ -25,7 +25,6 @@ import {
   sectionDescription,
   hubDescription,
   READING_LEAD,
-  READING_NOTE,
   SITE_URL,
 } from "../../content/etudeTexts";
 import GuestForm from "../../components/GuestForm.vue";
@@ -52,9 +51,8 @@ const textId = computed(() =>
 const sectionParam = computed(() => (route.params.section ? Number(route.params.section) : undefined));
 const sessionSlug = computed(() => (route.query.session ? String(route.query.session) : null));
 
-/** Reading lead/note are shown on the public /bibliotheque pages (not in the session reader). */
+/** Reading lead is shown on the public /bibliotheque pages (not in the session reader). */
 const readingLead = READING_LEAD;
-const readingNote = READING_NOTE;
 const isTehilimEtude = computed(
   () => isEtudeRoute.value && String(route.params.corpus) === "tehilim",
 );
@@ -711,12 +709,11 @@ watch(textId, loadContent);
         />
       </div>
 
-      <!-- SEO note + internal links (public /bibliotheque reading pages only) -->
+      <!-- Internal links (public /bibliotheque reading pages only) -->
       <section
         v-if="isEtudeRoute"
         class="mt-12 pt-6 border-t border-black/5 text-sm text-text-secondary dark:border-white/10 dark:text-gray-400"
       >
-        <p class="italic mb-4">{{ readingNote }}</p>
         <nav class="flex flex-wrap gap-x-5 gap-y-2">
           <RouterLink to="/bibliotheque" class="hover:text-primary transition-colors">Bibliothèque</RouterLink>
           <RouterLink


### PR DESCRIPTION
## Objectif

Retirer les phrases « défensives » qui sous-vendaient le travail (ton hésitant sur la qualité du contenu).

## Retiré
- **Pages de lecture** (`/bibliotheque/...`, prérendu **et** lecteur live) :
  > « Phonétique générée automatiquement comme aide à la lecture (approximative). Texte hébreu d'après le jeu de données public Sefaria. »
- **Pages « Tehilim par intention » + hub** : le bloc disclaimer
  > « Ces listes sont indicatives, selon les sources couramment citées… en cours de revalidation. »
- **`reussite`** : « Cette liste est provisoire… sera reconfirmée » (note + FAQ).
- CSS `.seo-note` devenu inutilisé.

## Conservé volontairement
- Le descriptif **« On lit traditionnellement les psaumes… »** (factuel, assumé, pas hésitant).
- La courtoisie religieuse **« En cas de doute, demandez conseil à votre rav »** dans les FAQ — c'est une politesse d'usage, pas un doute sur le travail.

> Si tu préfères **enlever aussi** le « demandez conseil à votre rav » (il revient ~7× dans les FAQ), dis-le et je le fais — j'ai préféré le garder par prudence.

## Vérifs
`type-check` ✅ · `vitest run` ✅ (83) · `lint` ✅ · `build` ✅ → plus aucune occurrence de « Phonétique générée / approximative / Sefaria / indicatives / provisoire / revalidation » dans `dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7R31bhFs9JgLqs1DKPq7W)_