### PR TITLE
fix: icône du bouton « Ajouter » (lecture quotidienne) + déploiement vert

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,5 +40,19 @@ jobs:
       # Deploys hosting (with the prerendered SEO pages) and the socialPreview
       # function together, so the hosting rewrites always resolve to a deployed
       # function. The functions are compiled by the predeploy hook in firebase.json.
+      # firebase-tools sometimes exits 1 on the final hosting "release" step with
+      # "supplied version <V> is the current active version" — even though <V> is
+      # the version that was just built and uploaded, i.e. the new content is
+      # already live. That makes the deploy a false failure. We swallow ONLY that
+      # exact, benign condition and still fail on any real deploy error.
       - name: Deploy hosting + functions
-        run: firebase deploy --only hosting,functions --project petite-jerusalem-dev --non-interactive
+        run: |
+          set +e
+          out=$(firebase deploy --only hosting,functions --project petite-jerusalem-dev --non-interactive 2>&1)
+          code=$?
+          echo "$out"
+          if [ "$code" -ne 0 ] && echo "$out" | grep -q "is the current active version"; then
+            echo "::warning::Hosting version already active — new content is live, treating as success."
+            exit 0
+          fi
+          exit "$code"

--- a/src/views/profilePage/DailyReading.vue
+++ b/src/views/profilePage/DailyReading.vue
@@ -260,7 +260,7 @@ function formatBookName(livre: string): string {
                   isSelected(text.id) ? 'text-primary' : 'text-text-secondary/60 dark:text-gray-500',
                 ]"
               >
-                <i :class="isSelected(text.id) ? 'fa-solid fa-circle-check' : 'fa-regular fa-circle-plus'"></i>
+                <i :class="isSelected(text.id) ? 'fa-solid fa-circle-check' : 'fa-solid fa-circle-plus'"></i>
                 {{ isSelected(text.id) ? t("dailyReading.added") : t("dailyReading.add") }}
               </span>
             </button>


### PR DESCRIPTION
Deux correctifs indépendants suite à la mise en ligne de la lecture quotidienne.

## 🐛 Icône manquante sur le bouton « Ajouter »
Dans l'onglet « Lecture quotidienne » → « Gérer ma liste », un carré de glyphe manquant s'affichait à côté de « Ajouter ».

**Cause :** `fa-circle-plus` n'existe pas dans le style *regular* de Font Awesome gratuit (uniquement en *solid*).
**Correctif :** `fa-regular fa-circle-plus` → `fa-solid fa-circle-plus`.

## 🚀 Déploiement : faux échec du workflow
Depuis le 28/06 (avant cette feature), le workflow `Deploy Release` finissait en échec alors que **le site était bien mis à jour**. L'échec venait uniquement de l'étape finale de mise en ligne du hosting, où `firebase-tools` renvoie :

```
HTTP Error: 400, Can't release to '.../channels/live':
supplied version <V> is the current active version.
```

`<V>` étant la version qui vient d'être buildée et uploadée, le nouveau contenu est déjà en ligne — l'erreur est bénigne.

**Correctif :** l'étape de deploy ne considère comme succès **que** cette condition exacte ; toute autre erreur fait toujours échouer le job. Indépendant de la version de `firebase-tools`.

## Suite
Après merge, créer un nouveau tag (ex. `v2.9.4`) pour relancer le déploiement et le voir passer au vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkTBH37DT8YfcHZR8HEj4z)_