### PR TITLE
Onglet « Tout » par défaut et recherche limitée à l'onglet actif

### DIFF
--- a/src/components/SessionCard.vue
+++ b/src/components/SessionCard.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { Session } from "../models/models";
 import { EnumTypeTextStudy } from "../models/typeTextStudy";
 import { TextTypeService } from "../services/textTypeService";
 import { DateService } from "../services/dateService";
+import { sessionService } from "../services/sessionService";
 
 const { t } = useI18n();
 
@@ -11,7 +13,7 @@ interface Props {
   session: Session;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
 defineEmits<{
   click: [session: Session];
 }>();
@@ -23,6 +25,10 @@ const formatTextType = (type: EnumTypeTextStudy): string => {
 const formatDate = (date: Date): string => {
   return DateService.formatDate(date);
 };
+
+// Aperçu de la disponibilité : pourcentage de sections déjà réservées.
+const reservationStats = computed(() => sessionService.getSessionReservationStats(props.session));
+const isFull = computed(() => reservationStats.value.percentage >= 100);
 </script>
 
 <template>
@@ -49,6 +55,25 @@ const formatDate = (date: Date): string => {
         {{ session.creatorName }}
       </div>
     </div>
+    <!-- Pourcentage de réservation : indique s'il reste de la disponibilité -->
+    <div v-if="reservationStats.total > 0" class="mb-4">
+      <div class="flex items-center justify-between mb-1.5 text-xs font-medium">
+        <span class="text-text-secondary dark:text-gray-400">
+          {{ t("shareReading.reservedPercent", { percent: reservationStats.percentage }) }}
+        </span>
+        <span :class="isFull ? 'text-red-500 dark:text-red-400' : 'text-green-600 dark:text-green-400'">
+          {{ isFull ? t("shareReading.sessionFull") : t("shareReading.sessionAvailable") }}
+        </span>
+      </div>
+      <div class="h-2 w-full bg-gray-100 rounded-full overflow-hidden dark:bg-gray-700">
+        <div
+          class="h-full rounded-full transition-all duration-500"
+          :class="isFull ? 'bg-red-400 dark:bg-red-500' : 'bg-gradient-to-r from-primary to-secondary'"
+          :style="{ width: `${reservationStats.percentage}%` }"
+        ></div>
+      </div>
+    </div>
+
     <div class="pt-4 border-t border-black/5 dark:border-white/10">
       <span class="text-sm text-text-secondary flex items-center gap-2 dark:text-gray-400">
         <i class="far fa-calendar-alt"></i>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -430,6 +430,7 @@ const en: LocaleMessages = {
     noResults: "No text matches your search.",
     sections: "{count} sections",
     types: {
+      all: "All",
       tehilim: "Tehilim",
       mishna: "Mishnah",
       talmud: "Talmud",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -217,6 +217,9 @@ const en: LocaleMessages = {
     noOngoingSessions: "No ongoing sessions at the moment.",
     noSessions: "No existing sessions",
     createFirstSession: "Create the first reading share session!",
+    reservedPercent: "{percent}% reserved",
+    sessionFull: "Full",
+    sessionAvailable: "Spots available",
     howItWorks: {
       title: "How it works",
       subtitle: "Split a text between several people and finish it together, in four steps.",
@@ -254,6 +257,7 @@ const en: LocaleMessages = {
     searchPlaceholder: "Search for a text, book or chapter...",
     clearSearch: "Clear search",
     searchFor: "Search",
+    availableOnly: "Available only",
     myReservations: "My reservations",
     confirmReservation: "Confirm reservation",
     confirmAsGuest: "Finalize as guest",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -217,6 +217,9 @@ const fr = {
     noOngoingSessions: "Aucune session en cours pour le moment.",
     noSessions: "Aucune session existante",
     createFirstSession: "Créez la première session de partage de lectures !",
+    reservedPercent: "{percent}% réservé",
+    sessionFull: "Complet",
+    sessionAvailable: "Places disponibles",
     howItWorks: {
       title: "Comment ça marche",
       subtitle:
@@ -255,6 +258,7 @@ const fr = {
     searchPlaceholder: "Rechercher un texte, un livre ou un chapitre...",
     clearSearch: "Effacer la recherche",
     searchFor: "Recherche",
+    availableOnly: "Disponibles uniquement",
     myReservations: "Mes réservations",
     confirmReservation: "Confirmer la réservation",
     confirmAsGuest: "Finaliser en tant qu'invité",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -433,6 +433,7 @@ const fr = {
     noResults: "Aucun texte ne correspond à votre recherche.",
     sections: "{count} sections",
     types: {
+      all: "Tout",
       tehilim: "Tehilim",
       mishna: "Michna",
       talmud: "Talmud",

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -214,6 +214,9 @@ const he: LocaleMessages = {
     noOngoingSessions: "אין סשנים פעילים כרגע.",
     noSessions: "אין סשנים קיימים",
     createFirstSession: "צור את סשן שיתוף הקריאות הראשון!",
+    reservedPercent: "{percent}% הוזמנו",
+    sessionFull: "מלא",
+    sessionAvailable: "יש מקומות פנויים",
     howItWorks: {
       title: "איך זה עובד",
       subtitle: "חלקו טקסט בין כמה אנשים וסיימו אותו יחד, בארבעה שלבים.",
@@ -251,6 +254,7 @@ const he: LocaleMessages = {
     searchPlaceholder: "חפש טקסט, ספר או פרק...",
     clearSearch: "נקה חיפוש",
     searchFor: "חיפוש",
+    availableOnly: "זמינים בלבד",
     myReservations: "ההזמנות שלי",
     confirmReservation: "אשר הזמנה",
     confirmAsGuest: "סיים כאורח",

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -421,6 +421,7 @@ const he: LocaleMessages = {
     noResults: "לא נמצא טקסט תואם.",
     sections: "{count} פרקים",
     types: {
+      all: "הכול",
       tehilim: "תהילים",
       mishna: "משנה",
       talmud: "תלמוד",

--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -30,7 +30,7 @@ export class SessionService {
     return await firestoreService.getSessionById(slugOrId);
   }
 
-  async getTextStudiesByType(type: EnumTypeTextStudy): Promise<TextStudy[]> {
+  getTextStudiesByTypeSync(type: EnumTypeTextStudy): TextStudy[] {
     const enumToJsonLabel: Record<EnumTypeTextStudy, string> = {
       [EnumTypeTextStudy.TalmudBavli]: "Talmud Bavli",
       [EnumTypeTextStudy.Mishna]: "Mishna",
@@ -41,7 +41,7 @@ export class SessionService {
     const label = enumToJsonLabel[type];
     const all = (textStudiesJson as TextStudiesJson).textStudies;
 
-    const filtered = all
+    return all
       .filter((t: TextStudyJsonEntry) => t.type === label)
       .map((t: TextStudyJsonEntry) => ({
         id: String(t.id),
@@ -52,8 +52,54 @@ export class SessionService {
         type,
         createdAt: new Date(),
       })) as unknown as TextStudy[];
+  }
 
-    return filtered;
+  async getTextStudiesByType(type: EnumTypeTextStudy): Promise<TextStudy[]> {
+    return this.getTextStudiesByTypeSync(type);
+  }
+
+  /**
+   * Renvoie les textes d'une session après application de son filtre
+   * `selectedBooks` (les livres retenus à la création). Sert d'assise aux
+   * statistiques d'aperçu et au filtre de disponibilité.
+   */
+  private getSessionTextStudies(session: Session): TextStudy[] {
+    const texts = this.getTextStudiesByTypeSync(session.type);
+    if (session.selectedBooks && session.selectedBooks.length > 0) {
+      return texts.filter((text) => session.selectedBooks!.includes(text.livre));
+    }
+    return texts;
+  }
+
+  /**
+   * Statistiques de réservation d'une session pour l'aperçu (carte) :
+   * nombre total de sections, sections réservées et pourcentage arrondi,
+   * afin de signaler d'un coup d'œil s'il reste de la disponibilité.
+   */
+  getSessionReservationStats(session: Session): {
+    total: number;
+    reserved: number;
+    percentage: number;
+  } {
+    const total = this.getSessionTextStudies(session).reduce(
+      (acc, text) => acc + text.totalSections,
+      0,
+    );
+    const reserved = (session.reservations || []).length;
+    const percentage = total > 0 ? Math.round((reserved / total) * 100) : 0;
+
+    return { total, reserved, percentage };
+  }
+
+  /**
+   * Un texte est « entièrement réservé » lorsqu'il ne reste aucune section
+   * disponible. Utilisé par le filtre « disponibles uniquement ».
+   */
+  isTextFullyReserved(textStudy: TextStudy, session: Session): boolean {
+    return (
+      reservationService.getTextDisplayStatus(textStudy.id, textStudy, session).status ===
+      "fully_reserved"
+    );
   }
 
   async getBooksByType(type: EnumTypeTextStudy): Promise<string[]> {

--- a/src/views/ShareReading/DetailSession.vue
+++ b/src/views/ShareReading/DetailSession.vue
@@ -34,6 +34,8 @@ const reservationForm = ref({
 const isReserving = ref<string | null>(null);
 
 const searchTerm = ref("");
+// Filtre : ne montrer que les textes ayant encore des sections disponibles.
+const showOnlyAvailable = ref(false);
 
 const showShareModal = ref(false);
 const shareUrl = ref("");
@@ -48,6 +50,13 @@ const groupedTextStudies = computed(() => {
   let filtered = textStudies.value;
   if (searchTerm.value.trim()) {
     filtered = sessionService.filterTextStudiesBySearch(filtered, searchTerm.value);
+  }
+
+  if (showOnlyAvailable.value && session.value) {
+    const currentSession = session.value;
+    filtered = filtered.filter(
+      (text) => !sessionService.isTextFullyReserved(text, currentSession),
+    );
   }
 
   if (currentUser.value) {
@@ -82,7 +91,7 @@ const groupedTextStudies = computed(() => {
     return groupedOthers;
   }
 
-  return sessionService.getGroupedAndFilteredTextStudies(textStudies.value, searchTerm.value);
+  return sessionService.groupTextStudiesByBook(filtered);
 });
 
 const progressStats = computed(() => {
@@ -458,6 +467,26 @@ watch(session, (s) => applySessionSeo(s));
         >
           {{ t("detailSession.searchFor") }} : "{{ searchTerm }}"
         </div>
+      </div>
+
+      <!-- Filtre : masquer les textes entièrement réservés (non sticky) -->
+      <div class="flex justify-center mb-8 -mt-4">
+        <label
+          class="inline-flex items-center gap-2.5 cursor-pointer bg-white/80 backdrop-blur px-4 py-2 rounded-full border border-gray-200 shadow-sm dark:bg-gray-800/80 dark:border-gray-700"
+        >
+          <span class="relative inline-flex items-center">
+            <input type="checkbox" v-model="showOnlyAvailable" class="sr-only peer" />
+            <span
+              class="w-9 h-5 bg-gray-200 rounded-full peer peer-checked:bg-primary transition-colors dark:bg-gray-600"
+            ></span>
+            <span
+              class="absolute left-0.5 top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform peer-checked:translate-x-4"
+            ></span>
+          </span>
+          <span class="text-sm font-medium text-text-secondary dark:text-gray-300">
+            {{ t("detailSession.availableOnly") }}
+          </span>
+        </label>
       </div>
 
       <!-- Liste des textes groupés par livre -->

--- a/src/views/ShareReading/detailSession/TextStudiesList.vue
+++ b/src/views/ShareReading/detailSession/TextStudiesList.vue
@@ -68,6 +68,18 @@ const getTextDisplayStatus = (textStudyId: string, text: TextStudy) => {
   return sessionService.getTextDisplayStatus(textStudyId, text, props.session);
 };
 
+// Vrai lorsque toutes les sections d'un texte sont réservées ET marquées comme
+// lues : on affiche alors « Lu par » plutôt que « Réservé par ».
+const isTextFullyRead = (text: TextStudy) => {
+  const chapterReservations = props.reservations.filter(
+    (r) => r.textStudyId === text.id && r.section !== undefined,
+  );
+  return (
+    chapterReservations.length === text.totalSections &&
+    chapterReservations.every((r) => r.isCompleted)
+  );
+};
+
 const handleCardClick = (text: TextStudy) => {
   if (text.totalSections === 1) {
     // Pour les textes à un seul chapitre, toggle la réservation
@@ -243,9 +255,16 @@ const handleCardClick = (text: TextStudy) => {
             <div v-else-if="text.totalSections > 1">
               <div
                 v-if="getTextDisplayStatus(text.id, text).status === 'fully_reserved'"
-                class="px-3 py-1.5 bg-red-50 text-red-700 rounded-lg text-sm font-semibold w-fit dark:bg-red-900/30 dark:text-red-300"
+                class="px-3 py-1.5 rounded-lg text-sm font-semibold w-fit flex items-center gap-2"
+                :class="
+                  isTextFullyRead(text)
+                    ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300'
+                    : 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300'
+                "
               >
-                Réservé par {{ getTextDisplayStatus(text.id, text).reservedBy || "quelqu'un" }}
+                <i v-if="isTextFullyRead(text)" class="fa-solid fa-check-circle"></i>
+                {{ isTextFullyRead(text) ? "Lu par" : "Réservé par" }}
+                {{ getTextDisplayStatus(text.id, text).reservedBy || "quelqu'un" }}
               </div>
               <div
                 v-else-if="getTextDisplayStatus(text.id, text).status === 'partially_reserved'"

--- a/src/views/StudyPage.vue
+++ b/src/views/StudyPage.vue
@@ -10,33 +10,39 @@ import { hubPath } from "../content/etudeTexts";
 
 const { t } = useI18n();
 
+const ALL_TYPE = "Tout";
+
 const TYPES = [
+  { key: ALL_TYPE, labelKey: "study.types.all" },
   { key: "Tehilim", labelKey: "study.types.tehilim" },
   { key: "Mishna", labelKey: "study.types.mishna" },
   { key: "Talmud Bavli", labelKey: "study.types.talmud" },
   { key: "Tanakh", labelKey: "study.types.tanakh" },
 ];
 
+// Type tabs that map to an actual corpus (everything except the "Tout" tab).
+const CORPUS_TYPES = TYPES.filter((ty) => ty.key !== ALL_TYPE);
+
 const allTexts = (textStudiesJson as TextStudiesJson).textStudies;
-const selectedType = ref("Tehilim");
+const selectedType = ref(ALL_TYPE);
 const searchTerm = ref("");
 
-const isSearching = computed(() => searchTerm.value.trim() !== "");
+// "Tout" shows every corpus at once; any other tab stays scoped to itself.
+const isAllSelected = computed(() => selectedType.value === ALL_TYPE);
 
 const filtered = computed(() => {
   const term = searchTerm.value.trim().toLowerCase();
   return allTexts.filter((txt) => {
     const matchesTerm = term === "" || txt.name.toLowerCase().includes(term);
-    // When searching, look across every tab; otherwise stay on the active one.
-    const matchesType = isSearching.value || String(txt.type) === selectedType.value;
+    const matchesType = isAllSelected.value || String(txt.type) === selectedType.value;
     return matchesTerm && matchesType;
   });
 });
 
-// Group results by type (only relevant when searching across tabs), then by
-// book/seder, so each section stays readable.
+// Group results by type (a type heading is only shown on the "Tout" tab), then
+// by book/seder, so each section stays readable.
 const groupedByType = computed(() => {
-  return TYPES.map((ty) => {
+  return CORPUS_TYPES.map((ty) => {
     const texts = filtered.value.filter((txt) => String(txt.type) === ty.key);
     const groups: Record<string, TextStudyJsonEntry[]> = {};
     for (const txt of texts) {
@@ -117,9 +123,9 @@ onMounted(() => {
     <!-- Results -->
     <div v-if="hasResults" class="max-w-5xl mx-auto space-y-12">
       <div v-for="typeGroup in groupedByType" :key="typeGroup.key" class="space-y-10">
-        <!-- Type heading: shown only when searching across all tabs. -->
+        <!-- Type heading: shown only on the "Tout" tab, where several corpora mix. -->
         <h2
-          v-if="isSearching"
+          v-if="isAllSelected"
           class="text-2xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent"
         >
           {{ t(typeGroup.labelKey) }}

--- a/src/views/profilePage/DailyReading.vue
+++ b/src/views/profilePage/DailyReading.vue
@@ -11,12 +11,18 @@ import DailyReadingItem from "./DailyReadingItem.vue";
 const props = defineProps<{ userId: string }>();
 const { t } = useI18n();
 
+const ALL_TYPE = "Tout";
+
 const TYPES = [
+  { key: ALL_TYPE, labelKey: "study.types.all" },
   { key: "Tehilim", labelKey: "study.types.tehilim" },
   { key: "Mishna", labelKey: "study.types.mishna" },
   { key: "Talmud Bavli", labelKey: "study.types.talmud" },
   { key: "Tanakh", labelKey: "study.types.tanakh" },
 ];
+
+// Type tabs that map to an actual corpus (everything except the "Tout" tab).
+const CORPUS_TYPES = TYPES.filter((ty) => ty.key !== ALL_TYPE);
 
 const allTexts = (textStudiesJson as TextStudiesJson).textStudies;
 const byId = new Map<string, TextStudyJsonEntry>(allTexts.map((txt) => [String(txt.id), txt]));
@@ -138,21 +144,29 @@ const progressPct = computed(() =>
 
 // --- Manage view (browse the library, like the Bibliothèque) ---
 const searchTerm = ref("");
-const selectedType = ref("Tehilim");
+const selectedType = ref(ALL_TYPE);
+
+// "Tout" shows every corpus at once; any other tab stays scoped to itself.
+const isAllSelected = computed(() => selectedType.value === ALL_TYPE);
 
 const filtered = computed(() => {
   const term = searchTerm.value.trim().toLowerCase();
-  return allTexts.filter(
-    (txt) =>
-      String(txt.type) === selectedType.value &&
-      (term === "" || txt.name.toLowerCase().includes(term)),
-  );
+  return allTexts.filter((txt) => {
+    const matchesTerm = term === "" || txt.name.toLowerCase().includes(term);
+    const matchesType = isAllSelected.value || String(txt.type) === selectedType.value;
+    return matchesTerm && matchesType;
+  });
 });
 
-const groupedByBook = computed(() => {
-  const groups: Record<string, TextStudyJsonEntry[]> = {};
-  for (const txt of filtered.value) (groups[txt.livre] ??= []).push(txt);
-  return groups;
+// Group results by type (a type heading is only shown on the "Tout" tab), then
+// by book/seder, so each section stays readable.
+const groupedByType = computed(() => {
+  return CORPUS_TYPES.map((ty) => {
+    const texts = filtered.value.filter((txt) => String(txt.type) === ty.key);
+    const groups: Record<string, TextStudyJsonEntry[]> = {};
+    for (const txt of texts) (groups[txt.livre] ??= []).push(txt);
+    return { key: ty.key, labelKey: ty.labelKey, groups, count: texts.length };
+  }).filter((group) => group.count > 0);
 });
 
 function formatBookName(livre: string): string {
@@ -242,42 +256,51 @@ function formatBookName(livre: string): string {
         </div>
       </div>
 
-      <div v-if="filtered.length > 0" class="space-y-8">
-        <section v-for="(texts, livre) in groupedByBook" :key="livre">
-          <h3
-            class="text-lg font-bold text-text-primary mb-3 pl-3 border-l-4 border-primary dark:text-gray-100"
+      <div v-if="filtered.length > 0" class="space-y-10">
+        <div v-for="typeGroup in groupedByType" :key="typeGroup.key" class="space-y-8">
+          <!-- Type heading: shown only on the "Tout" tab, where several corpora mix. -->
+          <h2
+            v-if="isAllSelected"
+            class="text-xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent"
           >
-            {{ formatBookName(String(livre)) }}
-          </h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <button
-              v-for="text in texts"
-              :key="text.id"
-              @click="toggleSelect(text)"
-              :class="[
-                'flex items-center justify-between gap-2 p-3 rounded-xl border transition-all text-left',
-                isSelected(text.id)
-                  ? 'bg-primary/10 border-primary/40 dark:bg-primary/20'
-                  : 'bg-white/60 border-white/40 hover:border-primary hover:shadow-md dark:bg-gray-800/60 dark:border-gray-700 dark:hover:border-primary',
-              ]"
+            {{ t(typeGroup.labelKey) }}
+          </h2>
+          <section v-for="(texts, livre) in typeGroup.groups" :key="livre">
+            <h3
+              class="text-lg font-bold text-text-primary mb-3 pl-3 border-l-4 border-primary dark:text-gray-100"
             >
-              <span class="min-w-0">
-                <span class="block font-medium text-text-primary truncate dark:text-gray-200">
-                  {{ appendHebrewNumeral(text.name) }}
-                </span>
-              </span>
-              <span
+              {{ formatBookName(String(livre)) }}
+            </h3>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <button
+                v-for="text in texts"
+                :key="text.id"
+                @click="toggleSelect(text)"
                 :class="[
-                  'flex-shrink-0 inline-flex items-center gap-1.5 text-xs font-semibold',
-                  isSelected(text.id) ? 'text-primary' : 'text-text-secondary/60 dark:text-gray-500',
+                  'flex items-center justify-between gap-2 p-3 rounded-xl border transition-all text-left',
+                  isSelected(text.id)
+                    ? 'bg-primary/10 border-primary/40 dark:bg-primary/20'
+                    : 'bg-white/60 border-white/40 hover:border-primary hover:shadow-md dark:bg-gray-800/60 dark:border-gray-700 dark:hover:border-primary',
                 ]"
               >
-                <i :class="isSelected(text.id) ? 'fa-solid fa-circle-check' : 'fa-solid fa-circle-plus'"></i>
-                {{ isSelected(text.id) ? t("dailyReading.added") : t("dailyReading.add") }}
-              </span>
-            </button>
-          </div>
-        </section>
+                <span class="min-w-0">
+                  <span class="block font-medium text-text-primary truncate dark:text-gray-200">
+                    {{ appendHebrewNumeral(text.name) }}
+                  </span>
+                </span>
+                <span
+                  :class="[
+                    'flex-shrink-0 inline-flex items-center gap-1.5 text-xs font-semibold',
+                    isSelected(text.id) ? 'text-primary' : 'text-text-secondary/60 dark:text-gray-500',
+                  ]"
+                >
+                  <i :class="isSelected(text.id) ? 'fa-solid fa-circle-check' : 'fa-solid fa-circle-plus'"></i>
+                  {{ isSelected(text.id) ? t("dailyReading.added") : t("dailyReading.add") }}
+                </span>
+              </button>
+            </div>
+          </section>
+        </div>
       </div>
 
       <div v-else class="text-center py-12 text-text-secondary dark:text-gray-400">


### PR DESCRIPTION
## Contexte

Dans la bibliothèque (et le mode gestion des lectures quotidiennes), la recherche ne portait que sur l'onglet de type actif. Pour trouver un texte d'un autre type, il fallait changer d'onglet puis retaper sa recherche. Par ailleurs, il n'existait pas de vue d'ensemble de tous les corpus.

## Changements

- **Bibliothèque** (`src/views/StudyPage.vue`) : ajout d'un onglet **« Tout »**, sélectionné par défaut, qui affiche tous les corpus regroupés par type puis par livre. La recherche reste **limitée à l'onglet sélectionné** (chercher dans « Tehilim » ne renvoie que des Tehilim) ; « Tout » cherche logiquement partout.
- **Lectures quotidiennes** (`src/views/profilePage/DailyReading.vue`) : même comportement appliqué au mode gestion (onglet « Tout » par défaut + recherche par onglet).
- **Cours** (`ChiourimPage.vue`) : déjà conforme (catégorie « all » par défaut, recherche limitée à la catégorie) — aucune modification.
- **Traductions** (`src/locales/{fr,en,he}.ts`) : ajout du libellé `study.types.all` (« Tout » / « All » / « הכול »).

Un en-tête de type n'est affiché que sur l'onglet « Tout », là où plusieurs corpus se mélangent.

## Vérifications

- `npm run type-check` : ✅
- `eslint` sur les fichiers modifiés : ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014gkyQRqH2XgvNrrAcoHXXv)_