### PR TITLE
Fix : slug de session immuable (liens de partage stables)

### DIFF
--- a/src/__tests__/sessionService.generateUniqueSlug.test.ts
+++ b/src/__tests__/sessionService.generateUniqueSlug.test.ts
@@ -99,36 +99,37 @@ describe("sessionService - slug unique à la mise à jour", () => {
     vi.mocked(firestoreService.updateSession).mockResolvedValue(undefined);
   });
 
-  it("réutilise son propre slug sans suffixe si le nom n'a pas changé", async () => {
-    vi.mocked(firestoreService.getSessionBySlug).mockResolvedValue(baseSession);
-
+  it("conserve le slug existant lors d'un renommage (les liens partagés restent valides)", async () => {
+    // Le slug fait office de lien de partage : renommer la session ne doit
+    // PAS le changer, sinon tous les liens déjà diffusés cassent.
     await sessionService.updateSession("abc123", {
-      name: "Étude du Talmud",
+      name: "Nom complètement différent",
       description: "desc",
       dateLimit: "2026-12-31",
+      slug: "etude-du-talmud",
     });
 
     expect(firestoreService.updateSession).toHaveBeenCalledWith(
       "abc123",
       expect.objectContaining({ slug: "etude-du-talmud" }),
     );
+    // On ne recalcule pas le slug quand il en existe déjà un.
+    expect(firestoreService.getSessionBySlug).not.toHaveBeenCalled();
   });
 
-  it("génère slug-1 si le nouveau nom est déjà pris par une autre session", async () => {
-    const otherSession = { ...baseSession, id: "other-id", slug: "nouveau-nom" };
-    vi.mocked(firestoreService.getSessionBySlug)
-      .mockResolvedValueOnce(otherSession) // "nouveau-nom" pris par autre session
-      .mockResolvedValueOnce(null); // "nouveau-nom-1" libre
+  it("génère un slug pour une session héritée qui n'en a pas encore", async () => {
+    vi.mocked(firestoreService.getSessionBySlug).mockResolvedValue(null);
 
     await sessionService.updateSession("abc123", {
-      name: "Nouveau nom",
+      name: "Étude du Talmud",
       description: "desc",
       dateLimit: "2026-12-31",
+      // slug absent : session héritée créée avant l'introduction des slugs.
     });
 
     expect(firestoreService.updateSession).toHaveBeenCalledWith(
       "abc123",
-      expect.objectContaining({ slug: "nouveau-nom-1" }),
+      expect.objectContaining({ slug: "etude-du-talmud" }),
     );
   });
 });

--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -438,10 +438,15 @@ export class SessionService {
 
   async updateSession(
     sessionId: string,
-    sessionData: { name: string; description: string; dateLimit: string },
+    sessionData: { name: string; description: string; dateLimit: string; slug?: string },
   ): Promise<void> {
     try {
-      const slug = await this.generateUniqueSlug(sessionData.name, sessionId);
+      // Le slug est l'identifiant public qui compose le lien de partage. On ne
+      // le régénère JAMAIS lors d'un renommage : sinon tous les liens déjà
+      // partagés deviennent « session introuvable ». On n'en génère un que pour
+      // les sessions héritées qui n'en ont pas encore.
+      const slug =
+        sessionData.slug?.trim() || (await this.generateUniqueSlug(sessionData.name, sessionId));
       await firestoreService.updateSession(sessionId, {
         name: sessionData.name,
         description: sessionData.description,

--- a/src/views/ProfilePage.vue
+++ b/src/views/ProfilePage.vue
@@ -137,7 +137,10 @@ const saveSessionChanges = async (sessionData: {
   if (!selectedSession.value) return;
 
   try {
-    await sessionService.updateSession(selectedSession.value.id, sessionData);
+    await sessionService.updateSession(selectedSession.value.id, {
+      ...sessionData,
+      slug: selectedSession.value.slug,
+    });
 
     const sessionIndex = createdSessions.value.findIndex((s) => s.id === selectedSession.value!.id);
     if (sessionIndex > -1) {


### PR DESCRIPTION
## Contexte

Retours utilisateurs sur les sessions de partage : des sessions étaient **introuvables** via leur lien de partage.

Diagnostic confirmé (relayé par un utilisateur) : **quand on renomme une session** dans « Modifier », le lien de partage, basé sur le nom (slug), est régénéré. Tous les liens déjà diffusés pointent alors vers un slug qui n'existe plus → « session introuvable ».

Exemple signalé : `/share-reading/session/etude-de-tout-le-talmud-leiloui-nichmat-rav-ron-chaya-1`

## Cause

`sessionService.updateSession()` appelait `generateUniqueSlug(name)` à **chaque** édition. Le slug étant l'identifiant public qui compose l'URL de partage, un renommage changeait l'URL et cassait tous les liens précédemment partagés.

## Correctif

Le slug devient **immuable** une fois créé :
- `updateSession` conserve le slug existant lors d'un renommage.
- Un slug n'est généré que pour les sessions **héritées** qui n'en ont pas encore (rétrocompatibilité).

`ProfilePage.vue` transmet désormais le slug courant de la session lors de la sauvegarde.

## Portée / limites

- Corrige la casse **future** des liens. Les liens déjà cassés (sessions déjà rencommées avant ce correctif) ne sont pas récupérables : l'ancien slug n'était stocké nulle part. Il faut reprendre le lien courant.

## Tests

- Tests unitaires mis à jour pour verrouiller le nouveau comportement (slug conservé au renommage ; génération uniquement pour les sessions sans slug).
- `vitest` : 83 tests OK · `vue-tsc` OK · `eslint` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)