### PR TITLE
Implement global audio player with mini player UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,8 @@ import StoneWallBackground from "./components/StoneWallBackground.vue";
 import SiteFooter from "./components/SiteFooter.vue";
 import ScrollToTop from "./components/ScrollToTop.vue";
 import ToastContainer from "./components/ToastContainer.vue";
+import GlobalAudioPlayer from "./components/GlobalAudioPlayer.vue";
+import { useMiniPlayerVisible } from "./composables/useAudioPlayer";
 import { RouterView } from "vue-router";
 import { onAuthStateChanged } from "firebase/auth";
 import { auth } from "../firebase";
@@ -17,6 +19,7 @@ const { loadTheme, resetTheme } = useTheme();
 const { loadFonts, resetFonts } = useFonts();
 
 const isHome = computed(() => route.name === "home");
+const isMiniPlayerVisible = useMiniPlayerVisible();
 
 onAuthStateChanged(auth, (user) => {
   if (user) {
@@ -34,6 +37,7 @@ onAuthStateChanged(auth, (user) => {
        transparent (the dark background lives on <body>) or it would hide it. -->
   <div
     class="min-h-screen flex flex-col text-text-primary transition-colors duration-300 dark:text-gray-100"
+    :class="{ 'pb-20': isMiniPlayerVisible }"
   >
     <StoneWallBackground />
     <Navbar />
@@ -41,5 +45,6 @@ onAuthStateChanged(auth, (user) => {
     <SiteFooter v-if="!isHome" />
     <ScrollToTop />
     <ToastContainer />
+    <GlobalAudioPlayer />
   </div>
 </template>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -80,6 +80,14 @@ body {
   flex-direction: column;
 }
 
+/* Les <main> des vues sont des flex items du layout colonne ci-dessus.
+   Leurs marges auto (mx-auto) désactivent le stretch : sans largeur définie,
+   ils passent en shrink-to-fit et le moindre contenu insécable (titre en
+   nowrap du lecteur audio…) élargit toute la page au-delà du viewport. */
+main {
+  width: 100%;
+}
+
 h1,
 h2,
 h3,

--- a/src/components/AudioPlayer.vue
+++ b/src/components/AudioPlayer.vue
@@ -2,38 +2,61 @@
 import { ref, computed, watch, onUnmounted } from "vue";
 import { useI18n } from "vue-i18n";
 import AppIcon from "./icons/AppIcon.vue";
+import { useAudioPlayer, formatTime } from "../composables/useAudioPlayer";
 
 const { t } = useI18n();
 
 interface Props {
   src: string;
   title?: string;
+  slug?: string;
 }
 
 const props = defineProps<Props>();
 
-const audio = ref<HTMLAudioElement | null>(null);
-const isPlaying = ref(false);
-const currentTime = ref(0);
-const duration = ref(0);
-const volume = ref(1);
-const previousVolume = ref(1);
-const playbackRate = ref(1);
-const isLoaded = ref(false);
+const player = useAudioPlayer();
 const showSpeedMenu = ref(false);
 
 const speeds = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 
-const formatTime = (seconds: number): string => {
-  if (!isFinite(seconds) || seconds < 0) return "0:00";
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.floor(seconds % 60);
-  const sStr = s.toString().padStart(2, "0");
-  if (h > 0) return `${h}:${m.toString().padStart(2, "0")}:${sStr}`;
-  return `${m}:${sStr}`;
-};
+// Ce composant est une vue sur le lecteur global : il est « actif » quand le
+// morceau chargé dans le lecteur global est le sien.
+const isCurrent = computed(() => player.track.value?.src === props.src);
+const isPlaying = computed(() => isCurrent.value && player.isPlaying.value);
 
+// Durée affichée avant lecture : sondée via un <audio> jetable (métadonnées
+// seules), sans toucher au lecteur global qui joue peut-être un autre morceau.
+const probedDuration = ref(0);
+let probe: HTMLAudioElement | null = null;
+
+function probeDuration(src: string) {
+  probedDuration.value = 0;
+  if (probe) {
+    probe.removeAttribute("src");
+    probe = null;
+  }
+  if (!src) return;
+  probe = new Audio();
+  probe.preload = "metadata";
+  probe.addEventListener("loadedmetadata", function (this: HTMLAudioElement) {
+    if (probe === this) probedDuration.value = this.duration;
+  });
+  probe.src = src;
+}
+
+watch(() => props.src, probeDuration, { immediate: true });
+
+onUnmounted(() => {
+  if (probe) {
+    probe.removeAttribute("src");
+    probe = null;
+  }
+});
+
+const currentTime = computed(() => (isCurrent.value ? player.currentTime.value : 0));
+const duration = computed(() =>
+  isCurrent.value && player.duration.value ? player.duration.value : probedDuration.value,
+);
 const progress = computed(() => {
   if (!duration.value) return 0;
   return (currentTime.value / duration.value) * 100;
@@ -41,110 +64,50 @@ const progress = computed(() => {
 
 const formattedCurrent = computed(() => formatTime(currentTime.value));
 const formattedDuration = computed(() => formatTime(duration.value));
-const isMuted = computed(() => volume.value === 0);
+const isMuted = computed(() => player.isMuted.value);
+const volume = computed(() => player.volume.value);
+const playbackRate = computed(() => player.playbackRate.value);
+
+function ownTrack() {
+  return { src: props.src, title: props.title ?? "", slug: props.slug };
+}
 
 function togglePlay() {
-  if (!audio.value) return;
-  if (isPlaying.value) {
-    audio.value.pause();
+  if (isCurrent.value) {
+    player.toggle();
   } else {
-    audio.value.play();
+    player.play(ownTrack());
   }
 }
 
 function seek(event: MouseEvent) {
-  if (!audio.value || !duration.value) return;
   const bar = event.currentTarget as HTMLElement;
   const rect = bar.getBoundingClientRect();
   const ratio = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
-  audio.value.currentTime = ratio * duration.value;
+  if (!isCurrent.value) player.play(ownTrack());
+  player.seekRatio(ratio);
 }
 
 function skip(seconds: number) {
-  if (!audio.value) return;
-  audio.value.currentTime = Math.max(
-    0,
-    Math.min(duration.value, audio.value.currentTime + seconds),
-  );
+  if (!isCurrent.value) return;
+  player.skip(seconds);
 }
 
 function setVolume(event: MouseEvent) {
   const bar = event.currentTarget as HTMLElement;
   const rect = bar.getBoundingClientRect();
   const ratio = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
-  volume.value = ratio;
-  if (audio.value) audio.value.volume = ratio;
-}
-
-function toggleMute() {
-  if (volume.value > 0) {
-    previousVolume.value = volume.value;
-    volume.value = 0;
-  } else {
-    volume.value = previousVolume.value || 1;
-  }
-  if (audio.value) audio.value.volume = volume.value;
+  player.setVolume(ratio);
 }
 
 function setSpeed(speed: number) {
-  playbackRate.value = speed;
-  if (audio.value) audio.value.playbackRate = speed;
+  player.setSpeed(speed);
   showSpeedMenu.value = false;
 }
-
-function onLoadedMetadata() {
-  if (audio.value) {
-    duration.value = audio.value.duration;
-    isLoaded.value = true;
-  }
-}
-
-function onTimeUpdate() {
-  if (audio.value) currentTime.value = audio.value.currentTime;
-}
-
-function onEnded() {
-  isPlaying.value = false;
-}
-
-function onPlay() {
-  isPlaying.value = true;
-}
-
-function onPause() {
-  isPlaying.value = false;
-}
-
-watch(
-  () => props.src,
-  () => {
-    isPlaying.value = false;
-    currentTime.value = 0;
-    duration.value = 0;
-    isLoaded.value = false;
-  },
-);
-
-onUnmounted(() => {
-  if (audio.value) {
-    audio.value.pause();
-  }
-});
 </script>
 
 <template>
   <div class="card p-6">
-    <audio
-      ref="audio"
-      :src="src"
-      preload="metadata"
-      @loadedmetadata="onLoadedMetadata"
-      @timeupdate="onTimeUpdate"
-      @ended="onEnded"
-      @play="onPlay"
-      @pause="onPause"
-    ></audio>
-
     <!-- Titre si fourni -->
     <p v-if="title" class="text-sm font-medium text-text-secondary mb-4 truncate">
       <AppIcon name="headphones" :size="14" class="mr-2 text-primary" />{{ title }}
@@ -176,7 +139,7 @@ onUnmounted(() => {
       <!-- Gauche : volume -->
       <div class="flex items-center gap-2 w-1/4">
         <button
-          @click="toggleMute"
+          @click="player.toggleMute()"
           class="text-text-secondary hover:text-primary transition-colors"
           :title="isMuted ? t('audioPlayer.unmute') : t('audioPlayer.mute')"
         >
@@ -200,7 +163,7 @@ onUnmounted(() => {
       <div class="flex items-center gap-4">
         <button
           @click="skip(-15)"
-          class="text-text-secondary hover:text-primary transition-colors text-sm"
+          class="inline-flex items-center whitespace-nowrap text-text-secondary hover:text-primary transition-colors text-sm"
           :title="t('audioPlayer.rewind')"
         >
           <AppIcon name="backward" :size="14" />
@@ -209,7 +172,7 @@ onUnmounted(() => {
 
         <button
           @click="togglePlay"
-          class="w-12 h-12 flex items-center justify-center bg-primary text-white rounded-full transition-colors"
+          class="w-12 h-12 flex items-center justify-center bg-primary text-white rounded-full transition-colors shrink-0"
           :title="isPlaying ? t('audioPlayer.pause') : t('audioPlayer.play')"
         >
           <AppIcon
@@ -221,7 +184,7 @@ onUnmounted(() => {
 
         <button
           @click="skip(30)"
-          class="text-text-secondary hover:text-primary transition-colors text-sm"
+          class="inline-flex items-center whitespace-nowrap text-text-secondary hover:text-primary transition-colors text-sm"
           :title="t('audioPlayer.forward')"
         >
           <span class="text-[10px] mr-0.5">30</span>

--- a/src/components/GlobalAudioPlayer.vue
+++ b/src/components/GlobalAudioPlayer.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
+import AppIcon from "./icons/AppIcon.vue";
+import {
+  useAudioPlayer,
+  useMiniPlayerVisible,
+  formatTime,
+} from "../composables/useAudioPlayer";
+import { computed } from "vue";
+
+const { t } = useI18n();
+const router = useRouter();
+
+const player = useAudioPlayer();
+const isVisible = useMiniPlayerVisible();
+
+const formattedCurrent = computed(() => formatTime(player.currentTime.value));
+const formattedDuration = computed(() => formatTime(player.duration.value));
+
+function seek(event: MouseEvent) {
+  const bar = event.currentTarget as HTMLElement;
+  const rect = bar.getBoundingClientRect();
+  const ratio = (event.clientX - rect.left) / rect.width;
+  player.seekRatio(ratio);
+}
+
+function goToChiour() {
+  if (player.track.value?.slug) {
+    router.push(`/chiourim/${player.track.value.slug}`);
+  }
+}
+</script>
+
+<template>
+  <Transition name="slide-up">
+    <div
+      v-if="isVisible && player.track.value"
+      class="fixed bottom-0 inset-x-0 z-40 bg-surface shadow-[0_-4px_20px_rgba(0,0,0,0.1)] pb-[env(safe-area-inset-bottom)]"
+      role="region"
+      :aria-label="t('audioPlayer.nowPlaying')"
+    >
+      <!-- Barre de progression cliquable, collée au bord haut -->
+      <div class="group relative h-1.5 bg-black/10 cursor-pointer dark:bg-white/10" @click="seek">
+        <div
+          class="absolute inset-y-0 left-0 bg-primary transition-[width] duration-100"
+          :style="{ width: `${player.progress.value}%` }"
+        ></div>
+      </div>
+
+      <div class="mx-auto max-w-4xl px-4 py-2.5 flex items-center gap-3">
+        <!-- Titre : lien vers la page du chiour -->
+        <button
+          class="flex items-center gap-2 min-w-0 flex-1 text-left text-sm font-medium text-text-primary hover:text-primary transition-colors"
+          :class="{ 'cursor-default hover:text-text-primary': !player.track.value.slug }"
+          @click="goToChiour"
+          :title="player.track.value.slug ? t('audioPlayer.goToChiour') : undefined"
+        >
+          <AppIcon name="headphones" :size="14" class="text-primary shrink-0" />
+          <span class="truncate">{{ player.track.value.title }}</span>
+        </button>
+
+        <!-- Temps (masqué en très petit écran) -->
+        <span class="hidden sm:block text-xs text-text-secondary whitespace-nowrap tabular-nums">
+          {{ formattedCurrent }} / {{ formattedDuration }}
+        </span>
+
+        <!-- Contrôles -->
+        <div class="flex items-center gap-3 shrink-0">
+          <button
+            @click="player.skip(-15)"
+            class="hidden sm:inline-flex items-center whitespace-nowrap text-text-secondary hover:text-primary transition-colors"
+            :title="t('audioPlayer.rewind')"
+          >
+            <AppIcon name="backward" :size="13" />
+            <span class="text-[9px] ml-0.5">15</span>
+          </button>
+
+          <button
+            @click="player.toggle()"
+            class="w-10 h-10 flex items-center justify-center bg-primary text-white rounded-full transition-colors shrink-0"
+            :title="player.isPlaying.value ? t('audioPlayer.pause') : t('audioPlayer.play')"
+          >
+            <AppIcon
+              :name="player.isPlaying.value ? 'pause' : 'play'"
+              :size="16"
+              :class="{ 'ml-0.5': !player.isPlaying.value }"
+            />
+          </button>
+
+          <button
+            @click="player.skip(30)"
+            class="hidden sm:inline-flex items-center whitespace-nowrap text-text-secondary hover:text-primary transition-colors"
+            :title="t('audioPlayer.forward')"
+          >
+            <span class="text-[9px] mr-0.5">30</span>
+            <AppIcon name="forward" :size="13" />
+          </button>
+
+          <button
+            @click="player.close()"
+            class="text-text-secondary hover:text-text-primary transition-colors ml-1"
+            :title="t('audioPlayer.close')"
+          >
+            <AppIcon name="x" :size="16" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.slide-up-enter-active,
+.slide-up-leave-active {
+  transition:
+    transform 0.25s ease,
+    opacity 0.25s ease;
+}
+.slide-up-enter-from,
+.slide-up-leave-to {
+  transform: translateY(100%);
+  opacity: 0;
+}
+</style>

--- a/src/components/ScrollToTop.vue
+++ b/src/components/ScrollToTop.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from "vue";
 import AppIcon from "./icons/AppIcon.vue";
+import { useMiniPlayerVisible } from "../composables/useAudioPlayer";
 
 const isVisible = ref(false);
+const isMiniPlayerVisible = useMiniPlayerVisible();
 
 const checkScroll = () => {
   isVisible.value = window.scrollY > 300;
@@ -36,7 +38,8 @@ onUnmounted(() => {
     <button
       v-if="isVisible"
       @click="scrollToTop"
-      class="fixed bottom-20 right-6 w-11 h-11 flex items-center justify-center rounded-full bg-surface text-text-primary shadow-pop hover:text-primary transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary z-50"
+      class="fixed right-6 w-11 h-11 flex items-center justify-center rounded-full bg-surface text-text-primary shadow-pop hover:text-primary transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary z-50"
+      :class="isMiniPlayerVisible ? 'bottom-36' : 'bottom-20'"
       aria-label="Retour en haut"
     >
       <AppIcon name="arrow-up" :size="18" />

--- a/src/composables/useAudioPlayer.ts
+++ b/src/composables/useAudioPlayer.ts
@@ -1,0 +1,216 @@
+import { ref, computed } from "vue";
+import { useRoute } from "vue-router";
+
+/**
+ * Lecteur audio global (singleton au niveau module).
+ *
+ * L'élément <audio> vit hors de l'arbre des composants : la lecture survit aux
+ * navigations. La page détail (AudioPlayer) et le mini-lecteur
+ * (GlobalAudioPlayer) pilotent tous deux cet état partagé.
+ */
+
+export interface AudioTrack {
+  src: string;
+  title: string;
+  /** Slug du chiour, pour relier le mini-lecteur à sa page détail. */
+  slug?: string;
+}
+
+const track = ref<AudioTrack | null>(null);
+const isPlaying = ref(false);
+const currentTime = ref(0);
+const duration = ref(0);
+const volume = ref(1);
+const previousVolume = ref(1);
+const playbackRate = ref(1);
+const isLoaded = ref(false);
+
+let audio: HTMLAudioElement | null = null;
+// Seek demandé avant que les métadonnées soient chargées (clic sur la barre
+// d'un morceau pas encore lancé) : appliqué dès loadedmetadata.
+let pendingSeekRatio: number | null = null;
+
+export function formatTime(seconds: number): string {
+  if (!isFinite(seconds) || seconds < 0) return "0:00";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  const sStr = s.toString().padStart(2, "0");
+  if (h > 0) return `${h}:${m.toString().padStart(2, "0")}:${sStr}`;
+  return `${m}:${sStr}`;
+}
+
+function updateMediaSession() {
+  if (!("mediaSession" in navigator) || !track.value) return;
+  navigator.mediaSession.metadata = new MediaMetadata({
+    title: track.value.title,
+    artist: "Petite Jerusalem",
+  });
+}
+
+function ensureAudio(): HTMLAudioElement {
+  if (audio) return audio;
+
+  audio = new Audio();
+  audio.preload = "metadata";
+
+  audio.addEventListener("loadedmetadata", () => {
+    if (!audio) return;
+    duration.value = audio.duration;
+    isLoaded.value = true;
+    if (pendingSeekRatio !== null) {
+      audio.currentTime = pendingSeekRatio * audio.duration;
+      pendingSeekRatio = null;
+    }
+  });
+  audio.addEventListener("timeupdate", () => {
+    if (audio) currentTime.value = audio.currentTime;
+  });
+  audio.addEventListener("play", () => {
+    isPlaying.value = true;
+  });
+  audio.addEventListener("pause", () => {
+    isPlaying.value = false;
+  });
+  audio.addEventListener("ended", () => {
+    isPlaying.value = false;
+  });
+
+  if ("mediaSession" in navigator) {
+    navigator.mediaSession.setActionHandler("play", () => audio?.play());
+    navigator.mediaSession.setActionHandler("pause", () => audio?.pause());
+    navigator.mediaSession.setActionHandler("seekbackward", () => skip(-15));
+    navigator.mediaSession.setActionHandler("seekforward", () => skip(30));
+  }
+
+  return audio;
+}
+
+function load(newTrack: AudioTrack) {
+  const el = ensureAudio();
+  if (track.value?.src === newTrack.src) {
+    // Même source : on rafraîchit juste les métadonnées (titre, slug).
+    track.value = newTrack;
+    updateMediaSession();
+    return;
+  }
+  track.value = newTrack;
+  currentTime.value = 0;
+  duration.value = 0;
+  isLoaded.value = false;
+  pendingSeekRatio = null;
+  el.src = newTrack.src;
+  el.volume = volume.value;
+  el.playbackRate = playbackRate.value;
+  updateMediaSession();
+}
+
+function play(newTrack?: AudioTrack) {
+  if (newTrack) load(newTrack);
+  ensureAudio()
+    .play()
+    .catch(() => {
+      // Lecture refusée (politique autoplay…) : l'état reste en pause.
+    });
+}
+
+function pause() {
+  audio?.pause();
+}
+
+function toggle() {
+  if (!audio || !track.value) return;
+  if (isPlaying.value) audio.pause();
+  else play();
+}
+
+function skip(seconds: number) {
+  if (!audio || !isLoaded.value) return;
+  audio.currentTime = Math.max(0, Math.min(duration.value, audio.currentTime + seconds));
+}
+
+function seekRatio(ratio: number) {
+  const clamped = Math.max(0, Math.min(1, ratio));
+  if (!audio || !isLoaded.value) {
+    pendingSeekRatio = clamped;
+    return;
+  }
+  audio.currentTime = clamped * duration.value;
+}
+
+function setVolume(v: number) {
+  volume.value = Math.max(0, Math.min(1, v));
+  if (audio) audio.volume = volume.value;
+}
+
+function toggleMute() {
+  if (volume.value > 0) {
+    previousVolume.value = volume.value;
+    setVolume(0);
+  } else {
+    setVolume(previousVolume.value || 1);
+  }
+}
+
+function setSpeed(speed: number) {
+  playbackRate.value = speed;
+  if (audio) audio.playbackRate = speed;
+}
+
+/** Arrête la lecture et ferme le mini-lecteur. */
+function close() {
+  if (audio) {
+    audio.pause();
+    audio.removeAttribute("src");
+    audio.load();
+  }
+  track.value = null;
+  isPlaying.value = false;
+  currentTime.value = 0;
+  duration.value = 0;
+  isLoaded.value = false;
+  pendingSeekRatio = null;
+}
+
+const progress = computed(() => {
+  if (!duration.value) return 0;
+  return (currentTime.value / duration.value) * 100;
+});
+
+const isMuted = computed(() => volume.value === 0);
+
+export function useAudioPlayer() {
+  return {
+    track,
+    isPlaying,
+    currentTime,
+    duration,
+    volume,
+    playbackRate,
+    isLoaded,
+    progress,
+    isMuted,
+    load,
+    play,
+    pause,
+    toggle,
+    skip,
+    seekRatio,
+    setVolume,
+    toggleMute,
+    setSpeed,
+    close,
+  };
+}
+
+/**
+ * Le mini-lecteur est visible dès qu'un morceau est chargé, sauf sur la page
+ * détail de ce même chiour (le lecteur complet y est déjà affiché).
+ */
+export function useMiniPlayerVisible() {
+  const route = useRoute();
+  return computed(() => {
+    if (!track.value) return false;
+    return !(route.name === "detail-chiour" && route.params.slug === track.value.slug);
+  });
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -410,6 +410,9 @@ const en: LocaleMessages = {
     rewind: "Rewind 15s",
     forward: "Forward 30s",
     speed: "Playback speed",
+    close: "Close player",
+    nowPlaying: "Now playing",
+    goToChiour: "Open the lesson page",
   },
   signupPrompt: {
     reservationConfirmed: "Reservation confirmed!",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -412,6 +412,9 @@ const fr = {
     rewind: "Reculer de 15s",
     forward: "Avancer de 30s",
     speed: "Vitesse de lecture",
+    close: "Fermer le lecteur",
+    nowPlaying: "Lecture en cours",
+    goToChiour: "Ouvrir la page du cours",
   },
   signupPrompt: {
     reservationConfirmed: "Réservation confirmée !",

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -402,6 +402,9 @@ const he: LocaleMessages = {
     rewind: "15 שניות אחורה",
     forward: "30 שניות קדימה",
     speed: "מהירות השמעה",
+    close: "סגירת הנגן",
+    nowPlaying: "מתנגן כעת",
+    goToChiour: "פתיחת דף השיעור",
   },
   signupPrompt: {
     reservationConfirmed: "ההזמנה אושרה!",

--- a/src/views/Chiourim/DetailChiour.vue
+++ b/src/views/Chiourim/DetailChiour.vue
@@ -159,7 +159,7 @@ watch(() => route.params.slug, loadChiour);
 
       <!-- Audio Player -->
       <div v-if="chiour.mediaUrl" class="mb-8">
-        <AudioPlayer :src="chiour.mediaUrl" :title="chiour.name" />
+        <AudioPlayer :src="chiour.mediaUrl" :title="chiour.name" :slug="chiour.slug" />
       </div>
 
       <div v-else class="mb-8 py-8 text-center">


### PR DESCRIPTION
## Summary
Refactored the audio player from a component-scoped implementation to a global singleton pattern, enabling persistent audio playback across page navigation. Added a new mini player component that appears when audio is playing outside of the lesson detail page.

## Key Changes

- **New composable `useAudioPlayer`**: Centralized audio state management at module level with a shared `HTMLAudioElement` instance that survives navigation. Includes:
  - Core playback controls (play, pause, toggle, skip, seek)
  - Volume and playback rate management
  - Media Session API integration for hardware controls
  - Pending seek handling for clicks before metadata loads
  - `formatTime()` utility for consistent time formatting

- **New `useMiniPlayerVisible()` composable**: Determines mini player visibility—shown when audio is loaded, hidden on the lesson detail page where the full player is displayed

- **New `GlobalAudioPlayer` component**: Compact fixed bottom player with:
  - Clickable progress bar
  - Play/pause toggle
  - Skip buttons (hidden on small screens)
  - Close button
  - Navigation link to lesson page
  - Slide-up/down transition animation

- **Refactored `AudioPlayer` component**: Now acts as a view on the global player state:
  - Removed local audio element and event listeners
  - Uses probed duration for display before playback starts
  - Delegates all playback to global player
  - Tracks whether it's the "current" playing track

- **Layout fixes**:
  - Added `width: 100%` to `<main>` to prevent horizontal overflow from unshrinkable content
  - Updated `ScrollToTop` button positioning to account for mini player

- **Localization**: Added new strings for close button, now playing label, and lesson page link in English, French, and Hebrew

- **Integration**: Updated `App.vue` to include `GlobalAudioPlayer` component and adjusted `DetailChiour.vue` to pass slug to `AudioPlayer`

## Implementation Details

The audio element lives outside the component tree, persisting across route changes. Both the full player (on lesson pages) and mini player (elsewhere) control the same global state. Pending seeks are queued if the user clicks the progress bar before metadata loads, then applied once `loadedmetadata` fires. The mini player automatically hides when navigating to the lesson page of the currently playing audio.

https://claude.ai/code/session_01FWja6ssU54dcSWpQyr45Qn