### PR TITLE
Remove gradle cache from deploy-android workflow

### DIFF
--- a/.github/workflows/deploy-android.yml
+++ b/.github/workflows/deploy-android.yml
@@ -66,12 +66,12 @@ jobs:
           cache: "npm"
 
       # Gradle/AGP de Capacitor 8 requièrent le JDK 21 (comme en local).
+      # Pas de `cache: gradle` : android/ est git-ignoré et n'est régénéré
       - name: Use JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
-          cache: gradle
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Removed gradle caching for JDK 21 setup in the workflow.