### PR TITLE
UX mobile : bibliothèque épurée, footer déplacé, recherche collante et nouvel accueil

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -74,7 +74,9 @@ onAuthStateChanged(auth, (user) => {
     <Navbar />
     <OfflineNotice v-if="showOfflineNotice" />
     <RouterView v-else />
-    <SiteFooter v-if="!isHome" />
+    <!-- App native : pas de footer de site ; l'essentiel (à propos, mentions
+         légales…) vit dans l'onglet À propos du profil. -->
+    <SiteFooter v-if="!isHome && !isNativeApp" />
     <ScrollToTop />
     <ToastContainer />
     <GlobalAudioPlayer />

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -281,6 +281,23 @@ button,
     color: var(--color-primary);
   }
 
+  /* App native : barre de recherche collante sous la barre système, pour
+     rester accessible pendant le scroll. Déborde du padding horizontal des
+     pages (px-6) pour couvrir toute la largeur de l'écran. */
+  .app-sticky-search {
+    position: sticky;
+    top: var(--safe-top);
+    z-index: 40;
+    margin-inline: -1.5rem;
+    padding: 0.5rem 1.5rem 0.75rem;
+    background-color: color-mix(in srgb, var(--color-bg-beige) 92%, transparent);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+  :root.dark .app-sticky-search {
+    background-color: color-mix(in srgb, #111827 92%, transparent);
+  }
+
   /* Modal building blocks — one modal style for the whole app. */
   .modal-overlay {
     position: fixed;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -75,10 +75,19 @@ const en: LocaleMessages = {
       },
     },
     comingSoon: "Coming Soon",
-    profileCard: {
-      title: "Hello {name}",
-      description:
-        "Your sessions, daily reading, reminders and preferences are waiting in your profile.",
+    dashboard: {
+      hello: "Hello",
+      helloEvening: "Good evening",
+      subtitle: "Here's where you stand today.",
+      readingEmpty: "Build the list of texts you read every day.",
+      readingCta: "Resume my reading",
+      readingSetupCta: "Pick my texts",
+      sessionsTitle: "My sessions",
+      endsToday: "ends today",
+      endsInDays: "ends in {count} d",
+      noEndingSoon: "{count} active session(s) — none ends this week.",
+      noSessions: "Join or create a shared study session.",
+      sessionsCta: "See Reading Share",
     },
     memorial: {
       title: "In memory of",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -114,6 +114,7 @@ const en: LocaleMessages = {
       myInfo: "My Information",
       security: "Security",
       preferences: "Preferences",
+      about: "About",
     },
     noParticipatedSessions: "No participated sessions",
     noParticipatedSessionsDesc: "You haven't participated in any study sessions yet.",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -112,6 +112,7 @@ const fr = {
       myInfo: "Mes Informations",
       security: "Sécurité",
       preferences: "Préférences",
+      about: "À propos",
     },
     noParticipatedSessions: "Aucune session participée",
     noParticipatedSessionsDesc: "Vous n'avez pas encore participé à des sessions d'étude.",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -73,10 +73,20 @@ const fr = {
       },
     },
     comingSoon: "Bientôt",
-    profileCard: {
-      title: "Bonjour {name}",
-      description:
-        "Vos sessions, votre lecture quotidienne, vos rappels et vos préférences vous attendent dans votre profil.",
+    dashboard: {
+      hello: "Bonjour",
+      helloEvening: "Bonsoir",
+      subtitle: "Voici où vous en êtes aujourd'hui.",
+      readingEmpty: "Composez la liste des textes que vous lisez chaque jour.",
+      readingCta: "Reprendre ma lecture",
+      readingSetupCta: "Choisir mes textes",
+      sessionsTitle: "Mes sessions",
+      endsToday: "se termine aujourd'hui",
+      endsInDays: "se termine dans {count} j",
+      noEndingSoon:
+        "{count} session(s) en cours — aucune ne se termine cette semaine.",
+      noSessions: "Rejoignez ou créez une session d'étude partagée.",
+      sessionsCta: "Voir le partage de lectures",
     },
     memorial: {
       title: "À la mémoire de",

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -75,9 +75,19 @@ const he: LocaleMessages = {
       },
     },
     comingSoon: "בקרוב",
-    profileCard: {
-      title: "שלום {name}",
-      description: "המפגשים, הקריאה היומית, התזכורות וההעדפות שלכם מחכים בפרופיל.",
+    dashboard: {
+      hello: "שלום",
+      helloEvening: "ערב טוב",
+      subtitle: "הנה איפה אתם עומדים היום.",
+      readingEmpty: "הרכיבו את רשימת הטקסטים שאתם קוראים כל יום.",
+      readingCta: "להמשיך בקריאה",
+      readingSetupCta: "לבחור טקסטים",
+      sessionsTitle: "הסשנים שלי",
+      endsToday: "מסתיים היום",
+      endsInDays: "מסתיים בעוד {count} ימים",
+      noEndingSoon: "{count} סשנים פעילים — אף אחד לא מסתיים השבוע.",
+      noSessions: "הצטרפו לסשן לימוד משותף או צרו אחד.",
+      sessionsCta: "לשיתוף הקריאות",
     },
     memorial: {
       title: "לזכר",

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -113,6 +113,7 @@ const he: LocaleMessages = {
       myInfo: "המידע שלי",
       security: "אבטחה",
       preferences: "העדפות",
+      about: "אודות",
     },
     noParticipatedSessions: "אין סשנים שהשתתפת בהם",
     noParticipatedSessionsDesc: "עדיין לא השתתפת בסשני לימוד.",

--- a/src/views/Chiourim/ChiourimPage.vue
+++ b/src/views/Chiourim/ChiourimPage.vue
@@ -7,6 +7,7 @@ import ChiourCard from "../../components/ChiourCard.vue";
 import AppIcon from "../../components/icons/AppIcon.vue";
 import AccountCta from "../../components/AccountCta.vue";
 import { seoService } from "../../services/seoService";
+import { isNativeApp } from "../../composables/useNativeApp";
 
 const { t } = useI18n();
 
@@ -80,21 +81,21 @@ onMounted(() => {
 
 <template>
   <main class="mx-auto px-6 py-12">
-    <!-- Header -->
-    <div class="text-center mb-12 animate-[fadeIn_0.5s_ease]">
-      <h2 class="text-4xl md:text-5xl font-bold text-text-primary mb-4 tracking-tight">
+    <!-- Header (le sous-titre explicatif ne sert que le site : SEO + découverte) -->
+    <div class="text-center animate-[fadeIn_0.5s_ease]" :class="isNativeApp ? 'mb-6' : 'mb-12'">
+      <h2 class="text-4xl md:text-5xl font-bold text-text-primary tracking-tight">
         {{ t("chiourim.title") }}
       </h2>
-      <p class="text-xl text-text-secondary max-w-2xl mx-auto leading-relaxed">
+      <p v-if="!isNativeApp" class="mt-4 text-xl text-text-secondary max-w-2xl mx-auto leading-relaxed">
         {{ t("chiourim.subtitle") }}
       </p>
     </div>
 
-    <!-- Filtres -->
+    <!-- Recherche : collante sur l'app pour rester accessible au scroll. -->
     <div
-      class="mb-10 flex flex-col md:flex-row gap-4 items-center justify-center animate-[fadeIn_0.5s_ease]"
+      :class="isNativeApp ? 'app-sticky-search' : ''"
+      class="flex justify-center mb-4 animate-[fadeIn_0.5s_ease]"
     >
-      <!-- Barre de recherche -->
       <div class="relative w-full md:w-96">
         <AppIcon
           name="search"
@@ -115,34 +116,34 @@ onMounted(() => {
           <AppIcon name="x" :size="14" />
         </button>
       </div>
+    </div>
 
-      <!-- Filtre par catégorie -->
-      <div class="flex flex-wrap gap-2 justify-center">
-        <button
-          @click="selectedCategory = 'all'"
-          class="chip transition-colors"
-          :class="
-            selectedCategory === 'all'
-              ? 'bg-primary text-white'
-              : 'bg-black/5 text-text-secondary hover:text-text-primary dark:bg-white/10'
-          "
-        >
-          {{ t("chiourim.allCategories") }}
-        </button>
-        <button
-          v-for="cat in dynamicCategories"
-          :key="cat"
-          @click="selectedCategory = cat"
-          class="chip transition-colors"
-          :class="
-            selectedCategory === cat
-              ? 'bg-primary text-white'
-              : 'bg-black/5 text-text-secondary hover:text-text-primary dark:bg-white/10'
-          "
-        >
-          {{ cat }}
-        </button>
-      </div>
+    <!-- Filtre par catégorie -->
+    <div class="mb-10 flex flex-wrap gap-2 justify-center animate-[fadeIn_0.5s_ease]">
+      <button
+        @click="selectedCategory = 'all'"
+        class="chip transition-colors"
+        :class="
+          selectedCategory === 'all'
+            ? 'bg-primary text-white'
+            : 'bg-black/5 text-text-secondary hover:text-text-primary dark:bg-white/10'
+        "
+      >
+        {{ t("chiourim.allCategories") }}
+      </button>
+      <button
+        v-for="cat in dynamicCategories"
+        :key="cat"
+        @click="selectedCategory = cat"
+        class="chip transition-colors"
+        :class="
+          selectedCategory === cat
+            ? 'bg-primary text-white'
+            : 'bg-black/5 text-text-secondary hover:text-text-primary dark:bg-white/10'
+        "
+      >
+        {{ cat }}
+      </button>
     </div>
 
     <div class="relative">

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -4,6 +4,7 @@ import { onMounted, onUnmounted, ref, computed, type Component } from "vue";
 import { useI18n } from "vue-i18n";
 import { seoService } from "../services/seoService";
 import { authService } from "../services/authService";
+import { isNativeApp } from "../composables/useNativeApp";
 import SiteFooter from "../components/SiteFooter.vue";
 import AccountCta from "../components/AccountCta.vue";
 import IllustrationPartage from "../components/illustrations/IllustrationPartage.vue";
@@ -66,7 +67,11 @@ onUnmounted(() => {
       <h2 class="text-3xl md:text-5xl font-bold text-text-primary tracking-tight">
         {{ t("home.heroTitle") }}
       </h2>
-      <p class="text-base md:text-lg text-text-secondary max-w-2xl mx-auto leading-relaxed">
+      <!-- Le descriptif ne sert que le site : SEO + premier contact. -->
+      <p
+        v-if="!isNativeApp"
+        class="text-base md:text-lg text-text-secondary max-w-2xl mx-auto leading-relaxed"
+      >
         {{ t("home.heroDescription") }}
       </p>
     </div>
@@ -133,7 +138,8 @@ onUnmounted(() => {
     </div>
   </main>
 
-  <SiteFooter />
+  <!-- App native : pas de footer de site (l'essentiel vit dans le profil). -->
+  <SiteFooter v-if="!isNativeApp" />
 </template>
 
 <style scoped>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -3,22 +3,92 @@ import { useRouter } from "vue-router";
 import { onMounted, onUnmounted, ref, computed, type Component } from "vue";
 import { useI18n } from "vue-i18n";
 import { seoService } from "../services/seoService";
-import { authService } from "../services/authService";
+import { authService, type User } from "../services/authService";
+import { userPreferencesService } from "../services/userPreferencesService";
+import { sessionService } from "../services/sessionService";
 import { isNativeApp } from "../composables/useNativeApp";
 import SiteFooter from "../components/SiteFooter.vue";
-import AccountCta from "../components/AccountCta.vue";
+import AppIcon from "../components/icons/AppIcon.vue";
 import IllustrationPartage from "../components/illustrations/IllustrationPartage.vue";
 import IllustrationChiourim from "../components/illustrations/IllustrationChiourim.vue";
 import IllustrationBibliotheque from "../components/illustrations/IllustrationBibliotheque.vue";
-import IllustrationProfil from "../components/illustrations/IllustrationProfil.vue";
 
 const router = useRouter();
 const { t } = useI18n();
 
-// Connecté : une carte dédiée pousse vers le profil (sessions, lecture
-// quotidienne, rappels… beaucoup de fonctionnalités y vivent).
-const username = ref<string | null>(null);
+const user = ref<User | null>(null);
 let unsubscribeAuth: (() => void) | null = null;
+
+// --- Tableau de bord (connecté) : lecture du jour + sessions qui se terminent. ---
+const dashLoading = ref(false);
+const readingTotal = ref(0);
+const readingDone = ref(0);
+const activeSessionsCount = ref(0);
+const endingSoon = ref<{ id: string; name: string; path: string; daysLeft: number }[]>([]);
+
+const firstName = computed(() => (user.value?.name ?? "").split(" ")[0] || user.value?.name || "");
+const greeting = computed(() => {
+  const hour = new Date().getHours();
+  return hour >= 18 || hour < 5 ? t("home.dashboard.helloEvening") : t("home.dashboard.hello");
+});
+const readingPct = computed(() =>
+  readingTotal.value === 0 ? 0 : Math.round((readingDone.value / readingTotal.value) * 100),
+);
+const readingAllDone = computed(
+  () => readingTotal.value > 0 && readingDone.value >= readingTotal.value,
+);
+
+/** Local calendar day (YYYY-MM-DD) — même convention que DailyReading. */
+function todayKey(): string {
+  const d = new Date();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${month}-${day}`;
+}
+
+async function loadDashboard(u: User) {
+  dashLoading.value = true;
+  try {
+    const [prefs, sessions] = await Promise.all([
+      userPreferencesService.getPreferences(u.id),
+      sessionService.getAllSessions().catch(() => []),
+    ]);
+
+    readingTotal.value = (prefs.dailyReadingIds ?? []).length;
+    const progress = prefs.dailyReadingProgress;
+    readingDone.value =
+      progress && progress.date === todayKey() ? progress.completedIds.length : 0;
+
+    // Sessions où l'utilisateur est impliqué (créées ou avec une réservation).
+    const mine = sessions.filter(
+      (s) =>
+        !s.isEnded &&
+        (s.personId === u.id ||
+          s.reservations?.some(
+            (r) => r.chosenById === u.id || r.chosenByGuestId === u.email,
+          )),
+    );
+    activeSessionsCount.value = mine.length;
+
+    const now = Date.now();
+    const week = 7 * 24 * 3600 * 1000;
+    endingSoon.value = mine
+      .map((s) => ({ s, msLeft: new Date(s.dateLimit).getTime() - now }))
+      .filter((x) => x.msLeft > 0 && x.msLeft <= week)
+      .sort((a, b) => a.msLeft - b.msLeft)
+      .slice(0, 3)
+      .map(({ s, msLeft }) => ({
+        id: s.id,
+        name: s.name,
+        path: `/share-reading/session/${s.slug || s.id}`,
+        daysLeft: Math.ceil(msLeft / (24 * 3600 * 1000)),
+      }));
+  } catch (error) {
+    console.error("Erreur lors du chargement du tableau de bord:", error);
+  } finally {
+    dashLoading.value = false;
+  }
+}
 
 const features = computed<
   { illustration: Component; title: string; description: string; route: string }[]
@@ -44,8 +114,16 @@ const features = computed<
 ]);
 
 onMounted(() => {
-  unsubscribeAuth = authService.onAuthChanged((user) => {
-    username.value = user?.name ?? null;
+  unsubscribeAuth = authService.onAuthChanged((u) => {
+    user.value = u;
+    if (u) {
+      loadDashboard(u);
+    } else {
+      readingTotal.value = 0;
+      readingDone.value = 0;
+      activeSessionsCount.value = 0;
+      endingSoon.value = [];
+    }
   });
   const url = window.location.origin + "/";
   seoService.setMeta({
@@ -62,45 +140,143 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <main class="flex-1 container mx-auto px-4 py-4 flex flex-col justify-center">
-    <div class="text-center mb-10 space-y-3">
+  <main class="flex-1 container mx-auto px-4 py-6 flex flex-col justify-center">
+    <!-- ===== Connecté : accueil personnalisé, hors carte ===== -->
+    <template v-if="user">
+      <div class="w-full max-w-6xl mx-auto mb-8">
+        <h2 class="text-3xl md:text-4xl font-bold text-text-primary tracking-tight">
+          {{ greeting }},
+          <span class="bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">{{
+            firstName
+          }}</span>
+        </h2>
+        <p class="text-text-secondary mt-1.5">{{ t("home.dashboard.subtitle") }}</p>
+      </div>
+
+      <div class="w-full max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-5 md:gap-6 mb-10">
+        <!-- Squelettes pendant le chargement -->
+        <template v-if="dashLoading">
+          <div class="card p-6 h-36 animate-pulse"></div>
+          <div class="card p-6 h-36 animate-pulse"></div>
+        </template>
+
+        <template v-else>
+          <!-- Lecture quotidienne : où j'en suis aujourd'hui -->
+          <RouterLink to="/profile" class="dash-card card card-hover p-6 block group">
+            <div class="flex items-center justify-between gap-3 mb-4">
+              <h3
+                class="font-bold text-text-primary flex items-center gap-2.5 group-hover:text-primary transition-colors"
+              >
+                <AppIcon name="book" :size="17" class="text-primary" />
+                {{ t("dailyReading.title") }}
+              </h3>
+              <AppIcon
+                name="chevron-right"
+                :size="15"
+                class="text-text-secondary/50 rtl:rotate-180"
+              />
+            </div>
+
+            <!-- Liste vide : inviter à la composer -->
+            <p v-if="readingTotal === 0" class="text-sm text-text-secondary leading-relaxed">
+              {{ t("home.dashboard.readingEmpty") }}
+            </p>
+
+            <template v-else>
+              <div class="flex items-center justify-between mb-2">
+                <span class="text-sm font-medium" :class="readingAllDone ? 'text-green-600 dark:text-green-400' : 'text-text-primary'">
+                  <template v-if="readingAllDone">
+                    {{ t("dailyReading.allReadTitle") }}
+                  </template>
+                  <template v-else>
+                    {{ t("dailyReading.progress", { done: readingDone, total: readingTotal }) }}
+                  </template>
+                </span>
+                <span class="text-sm font-semibold text-primary">{{ readingPct }}%</span>
+              </div>
+              <div class="h-2 w-full rounded-full bg-black/5 overflow-hidden dark:bg-white/10">
+                <div
+                  class="h-full rounded-full bg-primary transition-all duration-500"
+                  :style="{ width: `${readingPct}%` }"
+                ></div>
+              </div>
+            </template>
+
+            <p class="mt-4 text-sm font-medium text-primary flex items-center gap-1.5">
+              {{ readingTotal === 0 ? t("home.dashboard.readingSetupCta") : t("home.dashboard.readingCta") }}
+            </p>
+          </RouterLink>
+
+          <!-- Sessions : celles qui se terminent bientôt -->
+          <div class="dash-card card p-6" style="--enter-delay: 0.1s">
+            <h3 class="font-bold text-text-primary flex items-center gap-2.5 mb-4">
+              <AppIcon name="calendar" :size="17" class="text-primary" />
+              {{ t("home.dashboard.sessionsTitle") }}
+            </h3>
+
+            <!-- Des sessions se terminent cette semaine : les lister -->
+            <ul v-if="endingSoon.length > 0" class="flex flex-col divide-y divide-line">
+              <li v-for="session in endingSoon" :key="session.id">
+                <RouterLink
+                  :to="session.path"
+                  class="flex items-center justify-between gap-3 py-2 text-sm group"
+                >
+                  <span class="min-w-0 truncate font-medium text-text-primary group-hover:text-primary transition-colors">
+                    {{ session.name }}
+                  </span>
+                  <span
+                    class="shrink-0 flex items-center gap-1.5"
+                    :class="session.daysLeft <= 1 ? 'text-accent-secondary font-semibold' : 'text-text-secondary'"
+                  >
+                    <AppIcon name="hourglass" :size="13" />
+                    {{
+                      session.daysLeft <= 1
+                        ? t("home.dashboard.endsToday")
+                        : t("home.dashboard.endsInDays", { count: session.daysLeft })
+                    }}
+                  </span>
+                </RouterLink>
+              </li>
+            </ul>
+
+            <!-- Rien d'urgent -->
+            <p v-else-if="activeSessionsCount > 0" class="text-sm text-text-secondary leading-relaxed">
+              {{ t("home.dashboard.noEndingSoon", { count: activeSessionsCount }) }}
+            </p>
+            <p v-else class="text-sm text-text-secondary leading-relaxed">
+              {{ t("home.dashboard.noSessions") }}
+            </p>
+
+            <RouterLink
+              to="/share-reading"
+              class="mt-4 text-sm font-medium text-primary flex items-center gap-1.5 hover:underline"
+            >
+              {{ t("home.dashboard.sessionsCta") }}
+            </RouterLink>
+          </div>
+        </template>
+      </div>
+    </template>
+
+    <!-- ===== Non connecté : hero de bienvenue, CTA hors carte ===== -->
+    <div v-else class="text-center mb-10 space-y-4">
       <h2 class="text-3xl md:text-5xl font-bold text-text-primary tracking-tight">
         {{ t("home.heroTitle") }}
       </h2>
-      <!-- Le descriptif ne sert que le site : SEO + premier contact. -->
-      <p
-        v-if="!isNativeApp"
-        class="text-base md:text-lg text-text-secondary max-w-2xl mx-auto leading-relaxed"
-      >
+      <p class="text-base md:text-lg text-text-secondary max-w-2xl mx-auto leading-relaxed">
         {{ t("home.heroDescription") }}
       </p>
+      <div class="flex flex-wrap items-center justify-center gap-3 pt-2">
+        <RouterLink to="/login?mode=signup" class="btn btn-primary !px-7 !py-3">
+          {{ t("accountCta.signup") }}
+        </RouterLink>
+        <RouterLink to="/login" class="btn btn-soft !px-7 !py-3">
+          {{ t("accountCta.login") }}
+        </RouterLink>
+      </div>
     </div>
 
     <div class="w-full max-w-6xl mx-auto">
-      <!-- Connecté : invitation à explorer son profil, au-dessus des trois cartes.
-           Déconnecté : incitation à créer un compte (AccountCta se cache seul). -->
-      <button
-        v-if="username"
-        class="feature-card card card-hover group w-full flex items-center gap-5 p-6 text-left cursor-pointer mb-5 md:mb-6"
-        :style="{ '--enter-delay': '0s' }"
-        @click="router.push('/profile')"
-      >
-        <div class="flex-1 min-w-0">
-          <h3
-            class="text-lg font-bold mb-1.5 text-text-primary group-hover:text-primary transition-colors"
-          >
-            {{ t("home.profileCard.title", { name: username }) }}
-          </h3>
-          <p class="text-text-secondary text-sm leading-relaxed">
-            {{ t("home.profileCard.description") }}
-          </p>
-        </div>
-        <div class="w-24 h-24 sm:w-28 sm:h-28 md:w-24 md:h-24 lg:w-28 lg:h-28 shrink-0 text-primary">
-          <IllustrationProfil />
-        </div>
-      </button>
-      <AccountCta v-else class="mb-5 md:mb-6" />
-
       <div class="grid grid-cols-1 md:grid-cols-3 gap-5 md:gap-6 mb-10 items-stretch">
         <button
           v-for="(feature, index) in features"
@@ -143,8 +319,9 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
-/* Staggered entrance for the three feature cards. */
-.feature-card {
+/* Staggered entrance for the feature and dashboard cards. */
+.feature-card,
+.dash-card {
   opacity: 0;
   transform: translateY(14px);
   animation: card-enter 0.55s ease-out forwards;
@@ -159,7 +336,8 @@ onUnmounted(() => {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .feature-card {
+  .feature-card,
+  .dash-card {
     animation: none;
     opacity: 1;
     transform: none;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -143,7 +143,7 @@ onUnmounted(() => {
   <main class="flex-1 container mx-auto px-4 py-6 flex flex-col justify-center">
     <!-- ===== Connecté : accueil personnalisé, hors carte ===== -->
     <template v-if="user">
-      <div class="w-full max-w-6xl mx-auto mb-8">
+      <div class="w-full max-w-6xl mx-auto mb-8 enter-rise">
         <h2 class="text-3xl md:text-4xl font-bold text-text-primary tracking-tight">
           {{ greeting }},
           <span class="bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">{{
@@ -260,13 +260,19 @@ onUnmounted(() => {
 
     <!-- ===== Non connecté : hero de bienvenue, CTA hors carte ===== -->
     <div v-else class="text-center mb-10 space-y-4">
-      <h2 class="text-3xl md:text-5xl font-bold text-text-primary tracking-tight">
+      <h2 class="text-3xl md:text-5xl font-bold text-text-primary tracking-tight enter-rise">
         {{ t("home.heroTitle") }}
       </h2>
-      <p class="text-base md:text-lg text-text-secondary max-w-2xl mx-auto leading-relaxed">
+      <p
+        class="text-base md:text-lg text-text-secondary max-w-2xl mx-auto leading-relaxed enter-rise"
+        style="--enter-delay: 0.1s"
+      >
         {{ t("home.heroDescription") }}
       </p>
-      <div class="flex flex-wrap items-center justify-center gap-3 pt-2">
+      <div
+        class="flex flex-wrap items-center justify-center gap-3 pt-2 enter-rise"
+        style="--enter-delay: 0.2s"
+      >
         <RouterLink to="/login?mode=signup" class="btn btn-primary !px-7 !py-3">
           {{ t("accountCta.signup") }}
         </RouterLink>
@@ -305,7 +311,7 @@ onUnmounted(() => {
         </button>
       </div>
 
-      <div class="text-center max-w-2xl mx-auto">
+      <div class="text-center max-w-2xl mx-auto enter-rise" style="--enter-delay: 0.4s">
         <p class="font-serif italic text-text-secondary">{{ t("home.memorial.title") }}</p>
         <p class="mt-1 font-serif italic text-text-primary">
           {{ t("home.memorial.dedication") }}
@@ -319,9 +325,10 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
-/* Staggered entrance for the feature and dashboard cards. */
+/* Staggered entrance: cards, greeting/hero and memorial all rise into place. */
 .feature-card,
-.dash-card {
+.dash-card,
+.enter-rise {
   opacity: 0;
   transform: translateY(14px);
   animation: card-enter 0.55s ease-out forwards;
@@ -337,7 +344,8 @@ onUnmounted(() => {
 
 @media (prefers-reduced-motion: reduce) {
   .feature-card,
-  .dash-card {
+  .dash-card,
+  .enter-rise {
     animation: none;
     opacity: 1;
     transform: none;

--- a/src/views/ProfilePage.vue
+++ b/src/views/ProfilePage.vue
@@ -17,7 +17,9 @@ import UserInfoForm from "./profilePage/UserInfoForm.vue";
 import SecuritySettings from "./profilePage/SecuritySettings.vue";
 import PreferencesTab from "./profilePage/PreferencesTab.vue";
 import DailyReading from "./profilePage/DailyReading.vue";
+import AboutTab from "./profilePage/AboutTab.vue";
 import { useToast } from "../composables/useToast";
+import { isNativeApp } from "../composables/useNativeApp";
 
 const router = useRouter();
 const { t } = useI18n();
@@ -31,6 +33,7 @@ const activeTab = ref<
   | "my-info"
   | "security"
   | "preferences"
+  | "about"
 >("daily-reading");
 const isLoading = ref(true);
 
@@ -296,6 +299,20 @@ onMounted(async () => {
                 {{ t("profile.tabs.preferences") }}
               </button>
             </li>
+            <!-- App native uniquement : reprend l'essentiel du footer du site. -->
+            <li v-if="isNativeApp">
+              <button
+                @click="setActiveTab('about')"
+                :class="[
+                  'w-full text-left px-4 py-3 rounded-lg font-medium transition-colors',
+                  activeTab === 'about'
+                    ? 'bg-primary/10 text-primary font-semibold'
+                    : 'text-text-secondary hover:bg-black/5 hover:text-text-primary dark:hover:bg-white/10',
+                ]"
+              >
+                {{ t("profile.tabs.about") }}
+              </button>
+            </li>
           </ul>
 
           <button @click="authService.logout()" class="btn btn-danger w-full">
@@ -337,6 +354,10 @@ onMounted(async () => {
 
           <div v-if="activeTab === 'preferences'">
             <PreferencesTab :user-id="currentUser.id" />
+          </div>
+
+          <div v-if="activeTab === 'about'">
+            <AboutTab />
           </div>
         </div>
       </div>

--- a/src/views/ShareReading/ShareHomePage.vue
+++ b/src/views/ShareReading/ShareHomePage.vue
@@ -11,6 +11,7 @@ import AccountCta from "../../components/AccountCta.vue";
 import AppIcon from "../../components/icons/AppIcon.vue";
 import { seoService } from "../../services/seoService";
 import { authService } from "../../services/authService";
+import { isNativeApp } from "../../composables/useNativeApp";
 
 const router = useRouter();
 const { t } = useI18n();
@@ -181,7 +182,8 @@ const handleCreateClick = () => {
       <h2 class="text-4xl md:text-5xl font-bold text-text-primary mb-4 tracking-tight">
         {{ t("shareReading.title") }}
       </h2>
-      <p class="text-xl text-text-secondary max-w-2xl mx-auto leading-relaxed">
+      <!-- Le sous-titre explicatif ne sert que le site : SEO + découverte. -->
+      <p v-if="!isNativeApp" class="text-xl text-text-secondary max-w-2xl mx-auto leading-relaxed">
         {{ t("shareReading.subtitle") }}
       </p>
 

--- a/src/views/StudyPage.vue
+++ b/src/views/StudyPage.vue
@@ -143,18 +143,18 @@ onMounted(() => {
 
 <template>
   <main class="mx-auto px-6 py-12">
-    <!-- Hero -->
-    <div class="text-center mb-10">
-      <h1 class="text-4xl md:text-5xl font-bold text-text-primary mb-4 tracking-tight pb-1">
+    <!-- Hero (le sous-titre explicatif ne sert que le site : SEO + découverte) -->
+    <div class="text-center" :class="isNativeApp ? 'mb-6' : 'mb-10'">
+      <h1 class="text-4xl md:text-5xl font-bold text-text-primary tracking-tight pb-1">
         {{ t("study.title") }}
       </h1>
-      <p class="text-xl text-text-secondary max-w-2xl mx-auto leading-relaxed">
+      <p v-if="!isNativeApp" class="mt-4 text-xl text-text-secondary max-w-2xl mx-auto leading-relaxed">
         {{ t("study.subtitle") }}
       </p>
     </div>
 
-    <!-- Controls -->
-    <div class="flex flex-col items-center gap-4 mb-10">
+    <!-- Recherche : collante sur l'app pour rester accessible au scroll. -->
+    <div :class="isNativeApp ? 'app-sticky-search' : ''" class="flex justify-center mb-4">
       <div class="relative w-full md:w-96">
         <AppIcon
           name="search"
@@ -175,7 +175,10 @@ onMounted(() => {
           <AppIcon name="x" :size="14" />
         </button>
       </div>
+    </div>
 
+    <!-- Controls -->
+    <div class="flex flex-col items-center gap-4 mb-10">
       <!-- Filtres volontairement imposants : ils servent de porte d'entrée
            principale vers chaque corpus. -->
       <div class="flex flex-wrap gap-2.5 md:gap-3 justify-center">
@@ -246,47 +249,40 @@ onMounted(() => {
                   {{ t("study.sections", { count: text.totalSections }) }}
                 </span>
               </span>
-              <span class="shrink-0 flex items-center gap-1.5">
-                <!-- App native : télécharger/supprimer le livre sans quitter la bibliothèque. -->
-                <button
-                  v-if="bookState(text) !== 'none'"
-                  @click.prevent.stop="toggleDownload(text)"
-                  class="p-1 -m-1 transition-colors"
-                  :class="
-                    bookState(text) === 'downloaded'
-                      ? 'text-primary'
-                      : 'text-text-secondary/50 hover:text-primary'
-                  "
-                  :aria-label="
-                    bookState(text) === 'downloaded'
-                      ? t('downloads.delete')
-                      : t('downloads.download')
-                  "
-                  :title="
-                    bookState(text) === 'downloaded'
-                      ? t('downloads.delete')
-                      : t('downloads.download')
-                  "
-                >
-                  <AppIcon
-                    v-if="bookState(text) === 'downloading'"
-                    name="spinner"
-                    :size="15"
-                    class="animate-spin text-primary"
-                  />
-                  <AppIcon
-                    v-else-if="bookState(text) === 'downloaded'"
-                    name="circle-check"
-                    :size="15"
-                  />
-                  <AppIcon v-else name="download" :size="15" />
-                </button>
+              <!-- App native : télécharger/supprimer le livre sans quitter la bibliothèque. -->
+              <button
+                v-if="bookState(text) !== 'none'"
+                @click.prevent.stop="toggleDownload(text)"
+                class="shrink-0 p-1.5 -m-1.5 transition-colors"
+                :class="
+                  bookState(text) === 'downloaded'
+                    ? 'text-primary'
+                    : 'text-text-secondary/50 hover:text-primary'
+                "
+                :aria-label="
+                  bookState(text) === 'downloaded'
+                    ? t('downloads.delete')
+                    : t('downloads.download')
+                "
+                :title="
+                  bookState(text) === 'downloaded'
+                    ? t('downloads.delete')
+                    : t('downloads.download')
+                "
+              >
                 <AppIcon
-                  name="book-open"
-                  :size="16"
-                  class="text-text-secondary/40 group-hover:text-primary transition-colors"
+                  v-if="bookState(text) === 'downloading'"
+                  name="spinner"
+                  :size="19"
+                  class="animate-spin text-primary"
                 />
-              </span>
+                <AppIcon
+                  v-else-if="bookState(text) === 'downloaded'"
+                  name="circle-check"
+                  :size="19"
+                />
+                <AppIcon v-else name="download" :size="19" />
+              </button>
             </router-link>
           </div>
         </section>

--- a/src/views/StudyPage.vue
+++ b/src/views/StudyPage.vue
@@ -144,7 +144,7 @@ onMounted(() => {
 <template>
   <main class="mx-auto px-6 py-12">
     <!-- Hero (le sous-titre explicatif ne sert que le site : SEO + découverte) -->
-    <div class="text-center" :class="isNativeApp ? 'mb-6' : 'mb-10'">
+    <div class="text-center animate-[fadeIn_0.5s_ease]" :class="isNativeApp ? 'mb-6' : 'mb-10'">
       <h1 class="text-4xl md:text-5xl font-bold text-text-primary tracking-tight pb-1">
         {{ t("study.title") }}
       </h1>
@@ -154,7 +154,10 @@ onMounted(() => {
     </div>
 
     <!-- Recherche : collante sur l'app pour rester accessible au scroll. -->
-    <div :class="isNativeApp ? 'app-sticky-search' : ''" class="flex justify-center mb-4">
+    <div
+      :class="isNativeApp ? 'app-sticky-search' : ''"
+      class="flex justify-center mb-4 animate-[fadeIn_0.5s_ease]"
+    >
       <div class="relative w-full md:w-96">
         <AppIcon
           name="search"
@@ -178,7 +181,7 @@ onMounted(() => {
     </div>
 
     <!-- Controls -->
-    <div class="flex flex-col items-center gap-4 mb-10">
+    <div class="flex flex-col items-center gap-4 mb-10 animate-[fadeIn_0.5s_ease]">
       <!-- Filtres volontairement imposants : ils servent de porte d'entrée
            principale vers chaque corpus. -->
       <div class="flex flex-wrap gap-2.5 md:gap-3 justify-center">
@@ -223,7 +226,7 @@ onMounted(() => {
     </div>
 
     <!-- Results -->
-    <div v-if="hasResults" class="max-w-5xl mx-auto space-y-12">
+    <div v-if="hasResults" class="max-w-5xl mx-auto space-y-12 animate-[fadeIn_0.5s_ease]">
       <div v-for="typeGroup in groupedByType" :key="typeGroup.key" class="space-y-10">
         <!-- Type heading: shown only on the "Tout" tab, where several corpora mix. -->
         <h2 v-if="isAllSelected" class="text-2xl font-bold text-text-primary">

--- a/src/views/profilePage/AboutTab.vue
+++ b/src/views/profilePage/AboutTab.vue
@@ -17,7 +17,7 @@ const pages = [
 </script>
 
 <template>
-  <section class="card p-6">
+  <section class="card p-6 animate-[fadeIn_0.5s_ease]">
     <h2 class="text-2xl font-bold text-text-primary mb-6">
       {{ t("profile.tabs.about") }}
     </h2>

--- a/src/views/profilePage/AboutTab.vue
+++ b/src/views/profilePage/AboutTab.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import AppIcon from "../../components/icons/AppIcon.vue";
+
+/**
+ * App native uniquement : reprend l'essentiel du footer du site (retiré de
+ * l'app) — pages d'info, signalement de problème, crédits et réseaux.
+ */
+
+const { t } = useI18n();
+
+const pages = [
+  { to: "/a-propos", labelKey: "footer.about", icon: "info" },
+  { to: "/mentions-legales", labelKey: "footer.legal", icon: "align-left" },
+  { to: "/confidentialite", labelKey: "footer.privacy", icon: "eye" },
+] as const;
+</script>
+
+<template>
+  <section class="card p-6">
+    <h2 class="text-2xl font-bold text-text-primary mb-6">
+      {{ t("profile.tabs.about") }}
+    </h2>
+
+    <ul class="flex flex-col divide-y divide-line">
+      <li v-for="page in pages" :key="page.to">
+        <RouterLink
+          :to="page.to"
+          class="flex items-center justify-between gap-3 py-3.5 text-text-primary hover:text-primary transition-colors"
+        >
+          <span class="flex items-center gap-3">
+            <AppIcon :name="page.icon" :size="17" class="text-text-secondary/70" />
+            {{ t(page.labelKey) }}
+          </span>
+          <AppIcon name="chevron-right" :size="15" class="text-text-secondary/50 rtl:rotate-180" />
+        </RouterLink>
+      </li>
+      <li>
+        <a
+          href="https://phenixel.notion.site/26b35db90d4d809aada8e077937652d4?pvs=105"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center justify-between gap-3 py-3.5 text-text-primary hover:text-primary transition-colors"
+        >
+          <span class="flex items-center gap-3">
+            <AppIcon name="alert-circle" :size="17" class="text-text-secondary/70" />
+            {{ t("footer.reportIssue") }}
+          </span>
+          <AppIcon name="external-link" :size="15" class="text-text-secondary/50" />
+        </a>
+      </li>
+    </ul>
+
+    <div class="mt-6 pt-5 border-t border-line flex flex-wrap items-center justify-between gap-4">
+      <a
+        class="text-sm text-text-secondary hover:text-primary transition-colors font-medium"
+        href="https://phenixel.fr"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {{ t("footer.madeBy") }} <strong>Phenixel</strong> 🐦‍🔥
+      </a>
+      <div class="flex gap-4 items-center">
+        <a
+          class="flex items-center justify-center w-6 h-6 opacity-80 hover:opacity-100 transition-opacity text-text-secondary hover:text-text-primary"
+          href="https://github.com/Phenixel/PetiteJerusalem"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="GitHub"
+          title="GitHub"
+        >
+          <AppIcon name="github" :size="20" />
+        </a>
+        <a
+          class="flex items-center justify-center w-6 h-6 opacity-80 hover:opacity-100 transition-opacity text-text-secondary hover:text-text-primary"
+          href="https://x.com/Real_Phenixel"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="X"
+          title="X"
+        >
+          <AppIcon name="x-twitter" :size="18" />
+        </a>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/views/profilePage/DailyReading.vue
+++ b/src/views/profilePage/DailyReading.vue
@@ -255,7 +255,8 @@ function formatBookName(livre: string): string {
         <h2 class="text-2xl font-bold mb-2 text-text-primary">
           {{ t("dailyReading.title") }}
         </h2>
-        <p class="text-text-secondary max-w-xl">
+        <!-- Le descriptif ne sert que le site ; l'état vide explique déjà la fonction. -->
+        <p v-if="!isNativeApp" class="text-text-secondary max-w-xl">
           {{ t("dailyReading.description") }}
         </p>
       </div>
@@ -312,7 +313,8 @@ function formatBookName(livre: string): string {
         {{ t("dailyReading.selectedCount", { count: totalCount }) }}
       </p>
 
-      <div class="flex flex-col items-center gap-4 mb-8">
+      <!-- Recherche : collante sur l'app pour rester accessible au scroll. -->
+      <div :class="isNativeApp ? 'app-sticky-search' : ''" class="flex justify-center mb-4">
         <div class="relative w-full md:w-96">
           <AppIcon
             name="search"
@@ -333,7 +335,9 @@ function formatBookName(livre: string): string {
             <AppIcon name="x" :size="14" />
           </button>
         </div>
+      </div>
 
+      <div class="flex flex-col items-center gap-4 mb-8">
         <div class="flex flex-wrap gap-2 justify-center">
           <button
             v-for="ty in TYPES"


### PR DESCRIPTION
## Quoi

- **Bibliothèque** : le logo de livre disparaît des cartes de textes ; l'icône de téléchargement (app native) est agrandie (19 px) avec une zone tactile élargie.
- **App native — footer** : le footer de site n'est plus monté ; l'essentiel (À propos, Mentions légales, Confidentialité, Signaler un problème, crédits, GitHub/X) vit dans un nouvel onglet **« À propos »** du profil (app uniquement). Le choix de langue était déjà dans Préférences.
- **App native — textes d'intro** : les sous-titres explicatifs des pages principales (accueil connecté, bibliothèque, chiourim, partage, lecture quotidienne) sont masqués — ils ne servent que le site (SEO/découverte). Conservé pour les visiteurs non connectés sur l'accueil (premier contact).
- **Recherche collante** : les barres de recherche (bibliothèque, chiourim, gestion de la lecture quotidienne) restent collées en haut de l'écran au scroll sur l'app (`app-sticky-search`, sous la zone système, fond translucide flouté).
- **Nouvel accueil** :
  - Connecté : salutation personnalisée hors carte (Bonjour/Bonsoir + prénom en dégradé), widget **lecture quotidienne** (progression du jour, lien vers le profil) et widget **sessions se terminant sous 7 jours** (urgentes en avant, lien direct). Squelettes pendant le chargement.
  - Déconnecté : hero épuré (titre, descriptif, boutons Créer un compte / Se connecter hors carte) puis les trois cartes de découverte.
- **Animations d'apparition** : montée en cascade sur l'accueil, fondu d'entrée sur la bibliothèque et À propos (comme les chiourim), coupées avec `prefers-reduced-motion`.

## Vérifications

- `npm run verify` (type-check, lint, 83 tests) ✅
- Vérification visuelle dans Chromium : mode app simulé (bibliothèque + sticky au scroll, accueil, chiourim, onglet À propos) et mode web (footer et sous-titres intacts), connecté (données stubbées) et déconnecté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017J1wjCW8yHcZTr1jCz7Tia

---
_Generated by [Claude Code](https://claude.ai/code/session_017J1wjCW8yHcZTr1jCz7Tia)_