### PR TITLE
Confidentialité : corriger la mention Google Analytics et retirer les tirets longs

### DIFF
--- a/src/content/etudeTexts.ts
+++ b/src/content/etudeTexts.ts
@@ -154,9 +154,9 @@ export const READING_LEAD =
 /** A short human title for a section, used in H1 / breadcrumbs. */
 export function sectionHeading(entry: TextStudyJsonEntry, section: TextSection): string {
   const corpus = corpusOf(entry);
-  if (corpus === "tehilim") return `Tehilim ${slugOf(entry)} — Psaume ${slugOf(entry)}`;
+  if (corpus === "tehilim") return `Tehilim ${slugOf(entry)}, Psaume ${slugOf(entry)}`;
   if (corpus === "tanakh") return `Parashat ${latinName(entry)}`;
-  return `${CORPUS_LABEL[corpus]} ${latinName(entry)} — ${section.label}`;
+  return `${CORPUS_LABEL[corpus]} ${latinName(entry)}, ${section.label}`;
 }
 
 export function hubHeading(entry: TextStudyJsonEntry): string {

--- a/src/content/seoPages.ts
+++ b/src/content/seoPages.ts
@@ -521,7 +521,7 @@ const PRIVACY_FR: LegalStrings = {
         <li><strong>Notifications</strong> : si vous activez le rappel de lecture quotidien, un identifiant technique (jeton) de votre appareil, l'heure choisie et la langue de la notification.</li>
         <li><strong>Partage de lecture</strong> : si vous créez ou rejoignez une session partagée (Talmud, Tehilim…), le nom que vous indiquez (et votre email si vous participez sans créer de compte) est visible par toute personne disposant du lien de la session.</li>
       </ul>
-      <p>Nous ne collectons aucune donnée à des fins publicitaires et n'utilisons aucun outil de suivi ou d'analyse tiers (pas de Google Analytics, pas de traceur publicitaire).</p>`,
+      <p>Nous ne collectons aucune donnée à des fins publicitaires et n'utilisons aucun traceur publicitaire. Nous utilisons uniquement des outils de mesure d'audience (Google Analytics) afin de surveiller le bon fonctionnement de l'application et de l'améliorer.</p>`,
     },
     {
       heading: "Où sont hébergées ces données ?",
@@ -592,7 +592,7 @@ const PRIVACY_EN: LegalStrings = {
         <li><strong>Notifications</strong>: if you enable the daily reading reminder, a technical device token, the chosen time, and the notification language.</li>
         <li><strong>Shared reading</strong>: if you create or join a shared session (Talmud, Tehilim…), the name you provide (and your email if you take part without an account) is visible to anyone with the session link.</li>
       </ul>
-      <p>We do not collect any data for advertising purposes and do not use any third-party tracking or analytics tools (no Google Analytics, no ad tracker).</p>`,
+      <p>We do not collect any data for advertising purposes and do not use any ad trackers. We only use audience measurement tools (Google Analytics) to monitor the app's proper functioning and improve it.</p>`,
     },
     {
       heading: "Where is this data hosted?",
@@ -661,7 +661,7 @@ const PRIVACY_HE: LegalStrings = {
         <li><strong>התראות</strong>: אם תפעילו את תזכורת הקריאה היומית, אסימון מכשיר טכני, השעה שנבחרה ושפת ההתראה.</li>
         <li><strong>שיתוף קריאה</strong>: אם תיצרו או תצטרפו לפגישת קריאה משותפת (תלמוד, תהילים...), השם שתמסרו (והאימייל שלכם אם אתם משתתפים ללא חשבון) גלוי לכל מי שיש לו את קישור הפגישה.</li>
       </ul>
-      <p>איננו אוספים נתונים לצרכי פרסום ואיננו משתמשים בכלי מעקב או ניתוח של צד שלישי (ללא Google Analytics, ללא עוקב פרסומי).</p>`,
+      <p>איננו אוספים נתונים לצרכי פרסום ואיננו משתמשים בעוקבים פרסומיים. אנו משתמשים בכלי מדידת קהל (Google Analytics) בלבד כדי לנטר את תקינות האפליקציה ולשפר אותה.</p>`,
     },
     {
       heading: "היכן מאוחסנים הנתונים?",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -85,7 +85,7 @@ const en: LocaleMessages = {
       sessionsTitle: "My sessions",
       endsToday: "ends today",
       endsInDays: "ends in {count} d",
-      noEndingSoon: "{count} active session(s) — none ends this week.",
+      noEndingSoon: "{count} active session(s), none ends this week.",
       noSessions: "Join or create a shared study session.",
       sessionsCta: "See Reading Share",
     },

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -84,7 +84,7 @@ const fr = {
       endsToday: "se termine aujourd'hui",
       endsInDays: "se termine dans {count} j",
       noEndingSoon:
-        "{count} session(s) en cours — aucune ne se termine cette semaine.",
+        "{count} session(s) en cours, aucune ne se termine cette semaine.",
       noSessions: "Rejoignez ou créez une session d'étude partagée.",
       sessionsCta: "Voir le partage de lectures",
     },

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -85,7 +85,7 @@ const he: LocaleMessages = {
       sessionsTitle: "הסשנים שלי",
       endsToday: "מסתיים היום",
       endsInDays: "מסתיים בעוד {count} ימים",
-      noEndingSoon: "{count} סשנים פעילים — אף אחד לא מסתיים השבוע.",
+      noEndingSoon: "{count} סשנים פעילים, אף אחד לא מסתיים השבוע.",
       noSessions: "הצטרפו לסשן לימוד משותף או צרו אחד.",
       sessionsCta: "לשיתוף הקריאות",
     },


### PR DESCRIPTION
## Contexte

La politique de confidentialité affirmait à tort ne pas utiliser Google Analytics, alors qu'il est bien présent à des fins de monitoring de l'application. Correction du wording + nettoyage des tirets longs visibles à l'utilisateur.

## Changements

**Politique de confidentialité (`src/content/seoPages.ts`, FR/EN/HE)**
- Avant : « …n'utilisons aucun outil de suivi ou d'analyse tiers (pas de Google Analytics, pas de traceur publicitaire). »
- Après : « Nous ne collectons aucune donnée à des fins publicitaires et n'utilisons aucun traceur publicitaire. Nous utilisons uniquement des outils de mesure d'audience (Google Analytics) afin de surveiller le bon fonctionnement de l'application et de l'améliorer. »
- Vérifié : c'était la seule occurrence visible par l'utilisateur (pas de passage similaire ailleurs).

**Tirets longs (—) retirés des libellés visibles, remplacés par des virgules**
- `src/locales/fr.ts` / `en.ts` / `he.ts` → widget « Mes sessions » de l'accueil (`noEndingSoon`)
- `src/content/etudeTexts.ts` → titres de sections d'étude (H1 / fil d'Ariane)

Les autres `—` du dépôt sont dans des commentaires de code (non affichés) ou dans les textes source Talmud/Tanakh (contenu religieux, non modifié).

## Vérifications
- `tsc --noEmit` OK
- Aucun test ne dépend des chaînes modifiées

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwJDrYkP7bCAE6X4HW5i5y)_