### PR TITLE
fix(mobile): lift bottom-fixed UI above native tab bar & auto-hide scroll-to-top

### DIFF
--- a/src/components/BatchSelectionBar.vue
+++ b/src/components/BatchSelectionBar.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 import AppIcon from "./icons/AppIcon.vue";
+import { useBottomChromeHeight } from "../composables/useBottomChrome";
 
 const { t } = useI18n();
+
+// Se pose au-dessus des barres fixes du bas (bottom bar native, mini-lecteur)
+// pour ne plus être masquée par la barre de navigation de l'app.
+const bottomOffset = useBottomChromeHeight();
 
 defineProps<{
   count: number;
@@ -18,7 +23,11 @@ defineEmits<{
 </script>
 
 <template>
-  <div v-if="count > 0" class="fixed bottom-0 left-0 right-0 p-4 z-50 animate-[fadeIn_0.3s_ease]">
+  <div
+    v-if="count > 0"
+    class="fixed left-0 right-0 p-4 z-50 animate-[fadeIn_0.3s_ease]"
+    :style="{ bottom: bottomOffset }"
+  >
     <div
       class="max-w-2xl mx-auto bg-surface shadow-pop rounded-lg p-4 flex items-center justify-between gap-4"
     >

--- a/src/components/ScrollToTop.vue
+++ b/src/components/ScrollToTop.vue
@@ -5,6 +5,9 @@ import { useMiniPlayerVisible } from "../composables/useAudioPlayer";
 import { isNativeApp } from "../composables/useNativeApp";
 
 const isVisible = ref(false);
+// Le pointeur survole le bouton : on ne le masque pas sous la main de
+// l'utilisateur qui s'apprête à cliquer.
+const isHovered = ref(false);
 const isMiniPlayerVisible = useMiniPlayerVisible();
 
 // Reste au-dessus du mini-lecteur et, dans l'app, de la bottom bar.
@@ -13,8 +16,37 @@ const bottomClass = computed(() => {
   return isMiniPlayerVisible.value ? "bottom-36" : "bottom-20";
 });
 
+// Le bouton n'apparaît que pendant le défilement et s'efface après un court
+// temps d'inactivité : au repos (ex. en bas de l'accueil, sur la dédicace
+// « À la mémoire de »), il ne recouvre plus le contenu.
+const IDLE_HIDE_MS = 1600;
+let hideTimer: ReturnType<typeof setTimeout> | undefined;
+
+const armHideTimer = () => {
+  if (hideTimer) clearTimeout(hideTimer);
+  hideTimer = setTimeout(() => {
+    if (!isHovered.value) isVisible.value = false;
+  }, IDLE_HIDE_MS);
+};
+
 const checkScroll = () => {
-  isVisible.value = window.scrollY > 300;
+  if (window.scrollY > 300) {
+    isVisible.value = true;
+    armHideTimer();
+  } else {
+    if (hideTimer) clearTimeout(hideTimer);
+    isVisible.value = false;
+  }
+};
+
+const onPointerEnter = () => {
+  isHovered.value = true;
+  if (hideTimer) clearTimeout(hideTimer);
+};
+
+const onPointerLeave = () => {
+  isHovered.value = false;
+  armHideTimer();
 };
 
 const scrollToTop = () => {
@@ -25,11 +57,12 @@ const scrollToTop = () => {
 };
 
 onMounted(() => {
-  window.addEventListener("scroll", checkScroll);
+  window.addEventListener("scroll", checkScroll, { passive: true });
 });
 
 onUnmounted(() => {
   window.removeEventListener("scroll", checkScroll);
+  if (hideTimer) clearTimeout(hideTimer);
 });
 </script>
 
@@ -45,6 +78,8 @@ onUnmounted(() => {
     <button
       v-if="isVisible"
       @click="scrollToTop"
+      @pointerenter="onPointerEnter"
+      @pointerleave="onPointerLeave"
       class="fixed right-6 w-11 h-11 flex items-center justify-center rounded-full bg-surface text-text-primary shadow-pop hover:text-primary transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary z-50"
       :class="bottomClass"
       aria-label="Retour en haut"

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 import { useToast, type ToastType } from "../composables/useToast";
+import { useBottomChromeHeight } from "../composables/useBottomChrome";
 import AppIcon from "./icons/AppIcon.vue";
 import type { IconName } from "./icons/registry";
 
 const { t } = useI18n();
 const { toasts, dismiss } = useToast();
+
+// Empile les toasts au-dessus des barres fixes du bas (bottom bar native,
+// mini-lecteur) en conservant l'écart visuel d'origine (1.5rem).
+const bottomOffset = useBottomChromeHeight("1.5rem");
 
 const ICONS: Record<ToastType, { name: IconName; class: string }> = {
   success: { name: "circle-check", class: "text-emerald-500" },
@@ -16,7 +21,8 @@ const ICONS: Record<ToastType, { name: IconName; class: string }> = {
 
 <template>
   <div
-    class="fixed bottom-6 inset-x-0 z-[100] flex flex-col items-center gap-2 px-4 pointer-events-none"
+    class="fixed inset-x-0 z-[100] flex flex-col items-center gap-2 px-4 pointer-events-none"
+    :style="{ bottom: bottomOffset }"
     aria-live="polite"
   >
     <TransitionGroup name="toast">

--- a/src/composables/useBottomChrome.ts
+++ b/src/composables/useBottomChrome.ts
@@ -1,0 +1,29 @@
+import { computed, type ComputedRef } from "vue";
+import { useMiniPlayerVisible } from "./useAudioPlayer";
+import { isNativeApp } from "./useNativeApp";
+
+/**
+ * Hauteur occupée en bas de l'écran par les barres fixes empilées :
+ *   1. la bottom bar de l'app native (toujours présente dans l'app) ;
+ *   2. le mini-lecteur audio, posé juste au-dessus, quand il est ouvert.
+ *
+ * Sert à ancrer les éléments flottants du bas (barre de sélection multiple,
+ * toasts, bouton retour-en-haut) AU-DESSUS de ces barres, pour qu'ils ne
+ * soient plus masqués par la bottom bar native — le bug remonté sur l'app.
+ *
+ * Retourne une expression CSS `calc(...)` à passer en `style="{ bottom }"`.
+ * `extra` ajoute un écart supplémentaire (ex. marge visuelle des toasts).
+ */
+export function useBottomChromeHeight(extra = "0px"): ComputedRef<string> {
+  const isMiniPlayerVisible = useMiniPlayerVisible();
+  return computed(() => {
+    const layers: string[] = [extra];
+    // Réserve système du bas : bottom bar native (3.5rem) ou, sur le web,
+    // l'encoche safe-area des navigateurs mobiles.
+    if (isNativeApp) layers.push("3.5rem", "var(--safe-bottom)");
+    else layers.push("env(safe-area-inset-bottom, 0px)");
+    // Mini-lecteur audio empilé par-dessus (même hauteur web/natif).
+    if (isMiniPlayerVisible.value) layers.push("4.5rem");
+    return `calc(${layers.join(" + ")})`;
+  });
+}


### PR DESCRIPTION
- New useBottomChromeHeight composable computes the space taken by the stacked bottom chrome (native bottom bar + mini audio player) as a CSS calc().
- BatchSelectionBar ("X textes sélectionnés / Confirmer") and ToastContainer now anchor above that chrome, so the native app's bottom tab bar no longer covers them.
- ScrollToTop now only shows while scrolling and fades out after a short idle (staying put while hovered), so it stops overlapping the homepage "À la mémoire de" dedication when at rest.