### PR TITLE
Identifier le trafic de l'app dans PostHog et corriger la déconnexion depuis le profil

### DIFF
--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,4 +1,4 @@
-import type { PostHog } from "posthog-js";
+import type { BeforeSendFn, PostHog, Properties } from "posthog-js";
 import { appPlatform, isNativeApp } from "../composables/useNativeApp";
 import { getConsentChoice, onConsentChange } from "../composables/useConsent";
 import type { User } from "../models/models";
@@ -19,6 +19,50 @@ import type { User } from "../models/models";
 // Clé publique du projet PostHog (project settings → Project API key).
 const POSTHOG_KEY = "phc_qV5GtjgB46gGmPGpXq8edRXRK94jmgGkiNLdFA6tyRSW";
 const POSTHOG_HOST = "https://eu.i.posthog.com";
+
+/**
+ * Dans l'app, la webview Capacitor sert le bundle depuis `https://localhost` :
+ * les événements arrivent avec la même URL que du vrai trafic web local, et
+ * `$lib` vaut « web » (c'est bien posthog-js qui tourne). On réécrit donc
+ * l'origine en `app://android` / `app://ios` pour que l'app soit lisible d'un
+ * coup d'œil dans PostHog, sans toucher au chemin (les insights par page
+ * restent comparables entre le site et l'app).
+ */
+const NATIVE_ORIGIN = /^https?:\/\/localhost(?::\d+)?/;
+const APP_ORIGIN = `app://${appPlatform}`;
+const APP_HOST = `app.${appPlatform}`;
+const URL_KEYS = ["$current_url", "$referrer", "$initial_current_url", "$initial_referrer"];
+const HOST_KEYS = ["$host", "$initial_host", "$referring_domain", "$initial_referring_domain"];
+
+function rewriteNativeUrls(bag: Properties | undefined): void {
+  if (!bag) return;
+  for (const key of URL_KEYS) {
+    if (typeof bag[key] === "string") bag[key] = bag[key].replace(NATIVE_ORIGIN, APP_ORIGIN);
+  }
+  for (const key of HOST_KEYS) {
+    if (typeof bag[key] === "string" && bag[key].startsWith("localhost")) bag[key] = APP_HOST;
+  }
+}
+
+/**
+ * Estampille chaque événement avec la plateforme d'exécution.
+ *
+ * Passe par `before_send` plutôt que par `posthog.register()` : les super
+ * propriétés ne couvrent ni le `$pageview` initial (capturé pendant `init()`,
+ * donc avant tout `register()`), ni les événements qui suivent un `reset()`
+ * de déconnexion, qui vide la persistance. `before_send` s'applique à tout,
+ * y compris aux `$exception` d'Error tracking.
+ */
+const stampPlatform: BeforeSendFn = (event) => {
+  if (!event) return event;
+  event.properties.app_platform = appPlatform;
+  if (isNativeApp) {
+    rewriteNativeUrls(event.properties);
+    rewriteNativeUrls(event.$set);
+    rewriteNativeUrls(event.$set_once);
+  }
+  return event;
+};
 
 class AnalyticsService {
   private posthog: PostHog | null = null;
@@ -67,9 +111,9 @@ class AnalyticsService {
         // Dans la webview Capacitor, les cookies sur https://localhost sont
         // fragiles : localStorage est le stockage fiable.
         persistence: isNativeApp ? "localStorage" : "localStorage+cookie",
+        // Plateforme + URL lisible sur chaque événement (voir stampPlatform).
+        before_send: stampPlatform,
       });
-      // Présent sur chaque événement : permet de segmenter web / android / ios.
-      posthog.register({ app_platform: appPlatform });
       this.posthog = posthog;
 
       // Rattache les événements au compte dès qu'une session existe (connexion

--- a/src/views/ProfilePage.vue
+++ b/src/views/ProfilePage.vue
@@ -105,6 +105,16 @@ const loadTextStudiesForSessions = async (sessions: Session[]) => {
   }
 };
 
+// La garde de route ne se rejoue qu'à la navigation : sans redirection, la page
+// profil reste affichée après la déconnexion, avec ses menus, alors que toutes
+// les écritures Firestore sont désormais refusées (préférences, infos perso...).
+// On quitte donc la page tout de suite, en `replace` pour que le retour arrière
+// ne ramène pas sur un profil auquel on n'a plus accès.
+const logout = async () => {
+  await authService.logout();
+  router.replace("/");
+};
+
 const setActiveTab = (tab: typeof activeTab.value) => {
   // Quels onglets du profil sont réellement utilisés (menus latéraux).
   analyticsService.capture("profile_tab_opened", { tab });
@@ -323,7 +333,7 @@ onMounted(async () => {
             </li>
           </ul>
 
-          <button @click="authService.logout()" class="btn btn-danger w-full">
+          <button @click="logout" class="btn btn-danger w-full">
             <AppIcon name="logout" :size="15" />
             {{ t("common.logout") }}
           </button>


### PR DESCRIPTION
Deux commits, à tester ensemble : l'identification du trafic de l'app dans PostHog, et le correctif de la déconnexion depuis la page profil. Les deux se rejoignent sur la même exception remontée par Error tracking.

## 1. Identifier le trafic de l'app dans PostHog

### Problème

Dans PostHog, les événements envoyés depuis l'app mobile sont affichés avec l'URL `https://localhost/...` et la librairie `web`, exactement comme du trafic de dev local. Impossible de distinguer l'app du site.

Constat sur les 7 derniers jours du projet :

| app_platform | host | os | événements |
|---|---|---|---|
| `null` | localhost | Android | 81 |
| `android` | localhost | Android | 69 |
| `web` | petite-jerusalem.fr | Mac / Android | 52 |
| `web` / `null` | localhost:4173 | Mac | 29 |

La propriété `app_platform` existait déjà mais manquait sur plus de la moitié des événements de l'app. Deux causes visibles dans le détail par session :

1. le `$pageview` initial est capturé **pendant** `posthog.init()`, donc avant le `register()` qui suit (sessions à un seul événement non marqué) ;
2. `posthog.reset()`, appelé à la déconnexion depuis `authService`, vide les super propriétés : tous les événements suivants perdent `app_platform` jusqu'au prochain démarrage de l'app (sessions entièrement non marquées).

### Correction

- Le marquage passe de `register()` à un hook `before_send`, qui s'applique à chaque événement capturé, quel que soit le moment : premier pageview, événements post-`reset()`, et `$exception` d'Error tracking.
- Pour les plateformes natives uniquement, l'origine `https://localhost` de la webview Capacitor est réécrite en `app://android` / `app://ios`, sur `$current_url`, `$host`, le referrer et les propriétés `$initial_*` de `$set` / `$set_once`. Le chemin est conservé : les insights par page restent comparables entre le site et l'app.
- Le site web n'est pas touché (`isNativeApp` est faux, aucune réécriture, `app_platform` reste `web`).

`$lib` restera `web` même dans l'app, c'est attendu : c'est bien posthog-js qui tourne dans la webview. Le discriminant est `app_platform`.

## 2. Rediriger vers l'accueil après une déconnexion depuis le profil

### Problème

Le bouton de déconnexion de la page profil appelait `authService.logout()` sans quitter la page. La garde de route (`requiresAuth`) ne se rejoue qu'à la navigation : l'écran profil restait donc affiché, avec tous ses menus, alors que la session Firebase n'existait plus.

Résultat, l'utilisateur se croit connecté et toutes les écritures Firestore sont refusées par les rules, sans explication. Le seul contournement est de changer de page puis de revenir, ce qui déclenche enfin la redirection vers `/login`.

C'est exactement le scénario de l'exception remontée dans Error tracking :

```
Error: Failed to save font preference
https://localhost/profile
distinct_id: 019fa628-f60b-...  (anonyme)
```

L'erreur vient de `useFonts.setLatinFont`, dont l'écriture est rejetée par les rules, et le `distinct_id` anonyme confirme qu'elle est postérieure au `analyticsService.reset()` de la déconnexion. Cette même exception illustre le point 1 : son `app_platform` est `null`, précisément parce qu'elle suit un `reset()`.

Le cas se voit surtout dans l'app native : c'est le seul point de déconnexion, la navbar (qui redirigeait déjà via `router.push("/")`) n'y étant pas rendue.

### Correction

Le handler attend la fin de `authService.logout()` puis quitte la page :

```ts
const logout = async () => {
  await authService.logout()
  router.replace("/")
}
```

`replace` plutôt que `push` : le retour arrière ne doit pas ramener sur un profil auquel on n'a plus accès.

## Vérification

- `npm run type-check` : OK (vue-tsc couvre aussi la liaison du template)
- `eslint src/` : OK
- `vitest run` : 108 tests passent, 1 échec pré-existant sur `guestReservations` (localStorage indisponible dans cet environnement Node), identique sur `main` sans ces changements.

Aucun des deux parcours n'a été rejoué à la main : le marquage PostHog demande un build natif, la déconnexion demande une session authentifiée que je ne peux pas ouvrir. L'effet du point 1 n'est visible qu'après un `npm run app:build` et une nouvelle release, le SDK n'étant chargé qu'en build PROD.

## Notes

- Les événements déjà collectés ne sont pas corrigés rétroactivement. Sur l'historique, l'app se reconnaît à `$host = "localhost"` exact, sans port ; `localhost:4173` correspond aux `npm run preview` locaux.
- Piste de suite : marquer `$app_version` / `$app_build` depuis `@capacitor/app` dans le même hook, pour rattacher une hausse d'erreurs à une version précise du store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
