### PR TITLE
Rediriger vers l'accueil après une déconnexion depuis le profil

### DIFF
--- a/src/views/ProfilePage.vue
+++ b/src/views/ProfilePage.vue
@@ -105,6 +105,16 @@ const loadTextStudiesForSessions = async (sessions: Session[]) => {
   }
 };
 
+// La garde de route ne se rejoue qu'à la navigation : sans redirection, la page
+// profil reste affichée après la déconnexion, avec ses menus, alors que toutes
+// les écritures Firestore sont désormais refusées (préférences, infos perso...).
+// On quitte donc la page tout de suite, en `replace` pour que le retour arrière
+// ne ramène pas sur un profil auquel on n'a plus accès.
+const logout = async () => {
+  await authService.logout();
+  router.replace("/");
+};
+
 const setActiveTab = (tab: typeof activeTab.value) => {
   // Quels onglets du profil sont réellement utilisés (menus latéraux).
   analyticsService.capture("profile_tab_opened", { tab });
@@ -323,7 +333,7 @@ onMounted(async () => {
             </li>
           </ul>
 
-          <button @click="authService.logout()" class="btn btn-danger w-full">
+          <button @click="logout" class="btn btn-danger w-full">
             <AppIcon name="logout" :size="15" />
             {{ t("common.logout") }}
           </button>


### PR DESCRIPTION
## Problème

Le bouton de déconnexion de la page profil appelait `authService.logout()` sans quitter la page. La garde de route (`requiresAuth`) ne se rejoue qu'à la navigation : l'écran profil restait donc affiché, avec tous ses menus, alors que la session Firebase n'existait plus.

Résultat, l'utilisateur se croit connecté et toutes les écritures Firestore sont refusées par les rules, sans explication. Le seul contournement est de changer de page puis de revenir, ce qui déclenche enfin la redirection vers `/login`.

C'est exactement le scénario de l'exception remontée dans Error tracking :

```
Error: Failed to save font preference
https://localhost/profile
distinct_id: 019fa628-f60b-...  (anonyme)
```

L'erreur vient de `useFonts.setLatinFont`, dont l'écriture est rejetée par les rules, et le `distinct_id` anonyme confirme qu'elle est postérieure au `analyticsService.reset()` de la déconnexion.

Le cas se voit surtout dans l'app native : c'est le seul point de déconnexion, la navbar (qui redirigeait déjà via `router.push("/")`) n'y étant pas rendue.

## Correction

Le handler attend la fin de `authService.logout()` puis quitte la page :

```ts
const logout = async () => {
  await authService.logout()
  router.replace("/")
}
```

`replace` plutôt que `push` : le retour arrière ne doit pas ramener sur un profil auquel on n'a plus accès.

## Vérification

- `npm run type-check` : OK (vue-tsc couvre aussi la liaison du template)
- `eslint src/views/ProfilePage.vue` : OK
- `vitest run` : 108 tests passent, 1 échec pré-existant sur `guestReservations` (localStorage indisponible dans cet environnement Node), identique sur `main` sans ce changement.

Le parcours n'a pas été rejoué à la main : il demande une session authentifiée, que je ne peux pas ouvrir. À valider côté app en se déconnectant depuis l'onglet profil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
