### PR TITLE
Instrumenter les parcours produit dans PostHog

### DIFF
--- a/src/components/ShareModal.vue
+++ b/src/components/ShareModal.vue
@@ -2,6 +2,7 @@
 import { nextTick, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useToast } from "../composables/useToast";
+import { analyticsService } from "../services/analyticsService";
 import AppIcon from "./icons/AppIcon.vue";
 
 const { t } = useI18n();
@@ -17,6 +18,8 @@ interface Props {
   titleKey?: string;
   /** Clé i18n du message d'invitation pré-rempli ({name} interpolé). */
   messageKey?: string;
+  /** Nature du contenu partagé, pour les stats de viralité par type. */
+  contentType?: "session" | "chiour";
 }
 
 interface Emits {
@@ -104,22 +107,34 @@ const buildShareMessage = () => {
   return `${t(key, { name: props.sessionName })}\n\n${props.shareUrl}`;
 };
 
+/** Mesure la boucle virale : quel canal part le plus, pour quel contenu. */
+const trackChannel = (channel: "whatsapp" | "sms" | "facebook" | "copy") => {
+  analyticsService.capture("share_channel_selected", {
+    channel,
+    content_type: props.contentType ?? "session",
+  });
+};
+
 const shareToWhatsApp = () => {
+  trackChannel("whatsapp");
   const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(buildShareMessage())}`;
   window.open(whatsappUrl, "_blank");
 };
 
 const shareToSMS = () => {
+  trackChannel("sms");
   const smsUrl = `sms:?body=${encodeURIComponent(buildShareMessage())}`;
   window.location.href = smsUrl;
 };
 
 const shareToFacebook = () => {
+  trackChannel("facebook");
   const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(props.shareUrl)}`;
   window.open(facebookUrl, "_blank", "width=600,height=400");
 };
 
 const copyToClipboard = async () => {
+  trackChannel("copy");
   try {
     await navigator.clipboard.writeText(props.shareUrl);
     toast.success(t("shareModal.linkCopied"));
@@ -140,6 +155,10 @@ watch(
   () => props.show,
   (newValue) => {
     if (newValue) {
+      // Dénominateur du funnel de partage (ouvertures → canal choisi).
+      analyticsService.capture("share_modal_opened", {
+        content_type: props.contentType ?? "session",
+      });
       nextTick(() => {
         generateQRCode();
       });

--- a/src/components/SignupPromptModal.vue
+++ b/src/components/SignupPromptModal.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter, useRoute } from "vue-router";
+import { analyticsService } from "../services/analyticsService";
 import AppIcon from "./icons/AppIcon.vue";
 import type { IconName } from "./icons/registry";
 
@@ -48,11 +49,32 @@ const footerNote = computed(() =>
   isAuth.value ? t("signupPrompt.createSessionHaveAccount") : t("signupPrompt.alreadyHaveAccount"),
 );
 
+// Funnel invité → compte : la modale est le principal point de conversion.
+watch(
+  () => props.show,
+  (shown) => {
+    if (shown) {
+      analyticsService.capture("signup_prompt_shown", { variant: props.variant });
+    }
+  },
+);
+
+const trackAction = (action: "google" | "email" | "signin" | "later") => {
+  analyticsService.capture("signup_prompt_clicked", { variant: props.variant, action });
+};
+
 const closeModal = () => {
   emit("update:show", false);
 };
 
+/** Fermeture sans donner suite (« Plus tard », clic hors de la modale). */
+const dismiss = () => {
+  trackAction("later");
+  closeModal();
+};
+
 const goToLogin = (mode: "signup" | "google" | "login") => {
+  trackAction(mode === "signup" ? "email" : mode === "google" ? "google" : "signin");
   const currentPath = route.fullPath;
   const query: Record<string, string> = { redirect: currentPath };
   if (mode === "signup") {
@@ -69,7 +91,7 @@ const goToLogin = (mode: "signup" | "google" | "login") => {
 <template>
   <Teleport to="body">
     <Transition name="modal">
-      <div v-if="show" class="modal-overlay" @click="closeModal">
+      <div v-if="show" class="modal-overlay" @click="dismiss">
         <div class="modal-panel animate-[scaleIn_0.3s_ease]" @click.stop>
           <!-- Header : confirmation ou invitation à se connecter -->
           <div class="text-center">
@@ -130,7 +152,7 @@ const goToLogin = (mode: "signup" | "google" | "login") => {
             </button>
 
             <button
-              @click="closeModal"
+              @click="dismiss"
               class="w-full py-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
             >
               {{ t("signupPrompt.later") }}

--- a/src/composables/useAudioPlayer.ts
+++ b/src/composables/useAudioPlayer.ts
@@ -1,5 +1,6 @@
 import { ref, computed } from "vue";
 import { useRoute } from "vue-router";
+import { analyticsService } from "../services/analyticsService";
 
 /**
  * Lecteur audio global (singleton au niveau module).
@@ -29,6 +30,33 @@ let audio: HTMLAudioElement | null = null;
 // Seek demandé avant que les métadonnées soient chargées (clic sur la barre
 // d'un morceau pas encore lancé) : appliqué dès loadedmetadata.
 let pendingSeekRatio: number | null = null;
+
+// --- Engagement audio : écoute réelle, pas seulement des pages vues. ---
+// `chiour_played` une fois par morceau lancé, puis `chiour_progress` aux
+// jalons 25/50/75 (temps de lecture) et 100 (fin du morceau).
+let trackedSrc: string | null = null;
+const reachedMilestones = new Set<number>();
+
+function trackProperties() {
+  return {
+    chiour_slug: track.value?.slug ?? null,
+    chiour_title: track.value?.title ?? null,
+    duration_seconds: Math.round(duration.value) || null,
+  };
+}
+
+function trackPlayStarted() {
+  if (!track.value || track.value.src === trackedSrc) return;
+  trackedSrc = track.value.src;
+  reachedMilestones.clear();
+  analyticsService.capture("chiour_played", trackProperties());
+}
+
+function trackMilestone(milestone: number) {
+  if (!track.value || track.value.src !== trackedSrc || reachedMilestones.has(milestone)) return;
+  reachedMilestones.add(milestone);
+  analyticsService.capture("chiour_progress", { ...trackProperties(), milestone });
+}
 
 export function formatTime(seconds: number): string {
   if (!isFinite(seconds) || seconds < 0) return "0:00";
@@ -64,16 +92,25 @@ function ensureAudio(): HTMLAudioElement {
     }
   });
   audio.addEventListener("timeupdate", () => {
-    if (audio) currentTime.value = audio.currentTime;
+    if (!audio) return;
+    currentTime.value = audio.currentTime;
+    if (duration.value > 0) {
+      const pct = (audio.currentTime / duration.value) * 100;
+      if (pct >= 75) trackMilestone(75);
+      else if (pct >= 50) trackMilestone(50);
+      else if (pct >= 25) trackMilestone(25);
+    }
   });
   audio.addEventListener("play", () => {
     isPlaying.value = true;
+    trackPlayStarted();
   });
   audio.addEventListener("pause", () => {
     isPlaying.value = false;
   });
   audio.addEventListener("ended", () => {
     isPlaying.value = false;
+    trackMilestone(100);
   });
 
   if ("mediaSession" in navigator) {

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,6 +1,7 @@
 import type { BeforeSendFn, PostHog, Properties } from "posthog-js";
 import { appPlatform, isNativeApp } from "../composables/useNativeApp";
 import { getConsentChoice, onConsentChange } from "../composables/useConsent";
+import { i18n } from "../i18n";
 import type { User } from "../models/models";
 
 /**
@@ -53,9 +54,20 @@ function rewriteNativeUrls(bag: Properties | undefined): void {
  * de déconnexion, qui vide la persistance. `before_send` s'applique à tout,
  * y compris aux `$exception` d'Error tracking.
  */
+/**
+ * Le backoffice admin et le studio auteurs sont des outils internes : leurs
+ * événements pollueraient les stats produit (funnels, pageviews, replays).
+ */
+const INTERNAL_PATHS = /^\/(admin|studio)(\/|$)/;
+
 const stampPlatform: BeforeSendFn = (event) => {
   if (!event) return event;
+  if (INTERNAL_PATHS.test(window.location.pathname)) return null;
   event.properties.app_platform = appPlatform;
+  // Segmentation anonyme/connecté et par langue sur tous les événements, y
+  // compris les $pageview automatiques (mêmes raisons que app_platform).
+  event.properties.is_logged_in = isLoggedIn;
+  event.properties.locale = i18n.global.locale.value;
   if (isNativeApp) {
     rewriteNativeUrls(event.properties);
     rewriteNativeUrls(event.$set);
@@ -63,6 +75,11 @@ const stampPlatform: BeforeSendFn = (event) => {
   }
   return event;
 };
+
+// Tenu à jour par l'abonnement auth de load() ; false tant que Firebase n'a
+// pas restauré la session (les tout premiers événements d'un utilisateur
+// connecté peuvent donc partir en anonyme, c'est assumé).
+let isLoggedIn = false;
 
 class AnalyticsService {
   private posthog: PostHog | null = null;
@@ -121,6 +138,7 @@ class AnalyticsService {
       // Firebase dans le chemin de chargement de PostHog.
       const { authService } = await import("./authService");
       authService.onAuthChanged((user) => {
+        isLoggedIn = user != null;
         if (user) this.identify(user);
       });
     } catch {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -278,6 +278,9 @@ export class AuthService {
     }
 
     await deleteUser(user);
+    // Après le deleteUser (une suppression qui échoue ne doit pas compter),
+    // mais avant tout reset : l'événement reste rattaché au compte supprimé.
+    analyticsService.capture("account_deleted");
   }
 
   async reauthenticateWithGoogle(): Promise<void> {
@@ -320,6 +323,8 @@ export class AuthService {
     }
     const auth = getAuth(app);
     await signOut(auth);
+    // Capturé avant le reset pour rester rattaché au compte qui se déconnecte.
+    analyticsService.capture("signed_out");
     // Déconnexion explicite : les événements suivants repartent anonymes.
     analyticsService.reset();
   }

--- a/src/services/pushService.ts
+++ b/src/services/pushService.ts
@@ -5,6 +5,7 @@ import { arrayRemove, arrayUnion, doc, setDoc } from "firebase/firestore";
 import type { Router } from "vue-router";
 import { app, db } from "../../firebase";
 import { isNativeApp } from "../composables/useNativeApp";
+import { analyticsService } from "./analyticsService";
 
 /**
  * Notifications push (app native uniquement — le site web n'en envoie pas).
@@ -117,6 +118,8 @@ class PushService {
     // Deep-link quand l'utilisateur touche une notification push (`data.url`).
     FirebaseMessaging.addListener("notificationActionPerformed", (event) => {
       const url = (event.notification.data as { url?: string } | undefined)?.url;
+      // Efficacité du rappel quotidien : combien de retours viennent des push.
+      analyticsService.capture("push_notification_opened", { url: url ?? null });
       if (url) router.push(url);
     });
 
@@ -142,6 +145,7 @@ class PushService {
     // Toucher la notification locale doit deep-linker comme la push d'origine.
     LocalNotifications.addListener("localNotificationActionPerformed", (event) => {
       const url = (event.notification.extra as { url?: string } | undefined)?.url;
+      analyticsService.capture("push_notification_opened", { url: url ?? null });
       if (url) router.push(url);
     });
   }

--- a/src/services/reservationService.ts
+++ b/src/services/reservationService.ts
@@ -3,6 +3,7 @@ import { db } from "../../firebase";
 import { doc, runTransaction, collection, getDocs } from "firebase/firestore";
 import { firestoreService } from "./firestoreService";
 import { guestService } from "./guestService";
+import { analyticsService } from "./analyticsService";
 
 export interface ReservationForm {
   name: string;
@@ -445,6 +446,9 @@ export class ReservationService {
 
     if (migratedCount > 0) {
       firestoreService.invalidateSessionsCache();
+      // Preuve chiffrée du funnel « invité qui réserve → compte » : des
+      // réservations invité viennent d'être rattachées à un compte.
+      analyticsService.capture("guest_reservations_migrated", { migrated_count: migratedCount });
     }
     return migratedCount;
   }

--- a/src/views/Chiourim/DetailChiour.vue
+++ b/src/views/Chiourim/DetailChiour.vue
@@ -327,6 +327,7 @@ watch(() => route.params.slug, loadChiour);
       :share-url="shareUrl"
       title-key="shareModal.titleChiour"
       message-key="shareModal.inviteChiour"
+      content-type="chiour"
     />
   </main>
 </template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -3,6 +3,7 @@ import { useRouter } from "vue-router";
 import { onMounted, onUnmounted, ref, computed, type Component } from "vue";
 import { useI18n } from "vue-i18n";
 import { seoService } from "../services/seoService";
+import { analyticsService } from "../services/analyticsService";
 import { authService, type User } from "../services/authService";
 import { userPreferencesService } from "../services/userPreferencesService";
 import { sessionService } from "../services/sessionService";
@@ -113,9 +114,25 @@ const features = computed<
   },
 ]);
 
+// Ce que voit un visiteur qui (re)vient : la landing anonyme ou le tableau de
+// bord connecté. Une seule capture, au premier état d'auth connu.
+let hasTrackedHomeView = false;
+
+/** Clic sur un bloc de l'accueil : dit ce que les gens viennent y chercher. */
+const trackCard = (card: string) => {
+  analyticsService.capture("home_card_clicked", {
+    card,
+    variant: user.value ? "dashboard" : "landing",
+  });
+};
+
 onMounted(() => {
   unsubscribeAuth = authService.onAuthChanged((u) => {
     user.value = u;
+    if (!hasTrackedHomeView) {
+      hasTrackedHomeView = true;
+      analyticsService.capture("home_viewed", { variant: u ? "dashboard" : "landing" });
+    }
     if (u) {
       loadDashboard(u);
     } else {
@@ -162,7 +179,11 @@ onUnmounted(() => {
 
         <template v-else>
           <!-- Lecture quotidienne : où j'en suis aujourd'hui -->
-          <RouterLink to="/profile" class="dash-card card card-hover p-6 block group">
+          <RouterLink
+            to="/profile"
+            class="dash-card card card-hover p-6 block group"
+            @click="trackCard('daily_reading')"
+          >
             <div class="flex items-center justify-between gap-3 mb-4">
               <h3
                 class="font-bold text-text-primary flex items-center gap-2.5 group-hover:text-primary transition-colors"
@@ -220,6 +241,7 @@ onUnmounted(() => {
                 <RouterLink
                   :to="session.path"
                   class="flex items-center justify-between gap-3 py-2 text-sm group"
+                  @click="trackCard('ending_session')"
                 >
                   <span class="min-w-0 truncate font-medium text-text-primary group-hover:text-primary transition-colors">
                     {{ session.name }}
@@ -250,6 +272,7 @@ onUnmounted(() => {
             <RouterLink
               to="/share-reading"
               class="mt-4 text-sm font-medium text-primary flex items-center gap-1.5 hover:underline"
+              @click="trackCard('sessions_cta')"
             >
               {{ t("home.dashboard.sessionsCta") }}
             </RouterLink>
@@ -273,10 +296,14 @@ onUnmounted(() => {
         class="flex flex-wrap items-center justify-center gap-3 pt-2 enter-rise"
         style="--enter-delay: 0.2s"
       >
-        <RouterLink to="/login?mode=signup" class="btn btn-primary !px-7 !py-3">
+        <RouterLink
+          to="/login?mode=signup"
+          class="btn btn-primary !px-7 !py-3"
+          @click="trackCard('signup_cta')"
+        >
           {{ t("accountCta.signup") }}
         </RouterLink>
-        <RouterLink to="/login" class="btn btn-soft !px-7 !py-3">
+        <RouterLink to="/login" class="btn btn-soft !px-7 !py-3" @click="trackCard('login_cta')">
           {{ t("accountCta.login") }}
         </RouterLink>
       </div>
@@ -289,7 +316,10 @@ onUnmounted(() => {
           :key="feature.title"
           class="feature-card card card-hover group flex items-center gap-5 p-6 text-left cursor-pointer"
           :style="{ '--enter-delay': `${index * 0.12}s` }"
-          @click="router.push(feature.route)"
+          @click="
+            trackCard(`feature_${feature.route}`);
+            router.push(feature.route);
+          "
         >
           <!-- Texte à gauche, illustration à droite, tout reste dans la carte
                (une ligne par carte sur mobile, trois cartes côte à côte sur

--- a/src/views/ShareReading/DetailSession.vue
+++ b/src/views/ShareReading/DetailSession.vue
@@ -17,6 +17,7 @@ import SessionHeader from "./detailSession/SessionHeader.vue";
 import SessionInstructions from "./detailSession/SessionInstructions.vue";
 import TextStudiesList from "./detailSession/TextStudiesList.vue";
 import { useToast } from "../../composables/useToast";
+import { analyticsService } from "../../services/analyticsService";
 
 const route = useRoute();
 const router = useRouter();
@@ -47,6 +48,20 @@ const shareUrl = ref("");
 const selectedItems = ref<Set<string>>(new Set());
 const isSubmittingBatch = ref(false);
 const showSignupPrompt = ref(false);
+
+// Funnel réservation : un seul événement par visite pour la 1re sélection et
+// la 1re recherche, sinon chaque clic de chapitre noierait les stats.
+let hasTrackedSelection = false;
+let hasTrackedSearch = false;
+
+const trackFirstSelection = () => {
+  if (hasTrackedSelection) return;
+  hasTrackedSelection = true;
+  analyticsService.capture("session_section_selected", {
+    session_id: session.value?.id,
+    is_authenticated: currentUser.value != null,
+  });
+};
 
 const groupedTextStudies = computed(() => {
   if (!textStudies.value.length) return {};
@@ -216,6 +231,7 @@ const handleToggleSelectAll = (textStudyId: string) => {
     availableKeys.forEach((key) => selectedItems.value.delete(key));
   } else {
     availableKeys.forEach((key) => selectedItems.value.add(key));
+    if (availableKeys.length > 0) trackFirstSelection();
   }
 };
 
@@ -237,16 +253,29 @@ const handleItemClick = (textStudyId: string, section?: number) => {
     selectedItems.value.delete(key);
   } else {
     selectedItems.value.add(key);
+    trackFirstSelection();
   }
 };
 
 const confirmReservations = async () => {
   if (!session.value || selectedItems.value.size === 0) return;
 
+  analyticsService.capture("reservation_confirm_clicked", {
+    session_id: session.value.id,
+    sections_count: selectedItems.value.size,
+    is_guest: currentUser.value == null,
+    source: "session_page",
+  });
+
   if (
     !currentUser.value &&
     (!reservationForm.value.name || (guestEmailRequired.value && !reservationForm.value.email))
   ) {
+    analyticsService.capture("reservation_failed", {
+      session_id: session.value.id,
+      reason: !reservationForm.value.name ? "missing_name" : "missing_email",
+      source: "session_page",
+    });
     toast.info(
       guestEmailRequired.value ? t("detailSession.fillNameAndEmail") : t("detailSession.fillName"),
     );
@@ -301,6 +330,15 @@ const confirmReservations = async () => {
     reservations.value.push(...newReservations);
     selectedItems.value.clear();
 
+    analyticsService.capture("reservation_completed", {
+      session_id: session.value.id,
+      text_type: session.value.type,
+      sections_count: newReservations.length,
+      is_guest: currentUser.value == null,
+      guest_has_email: currentUser.value == null && reservationForm.value.email.trim() !== "",
+      source: "session_page",
+    });
+
     if (!currentUser.value) {
       // Les invités voient la modale d'inscription, qui confirme déjà la réservation.
       showSignupPrompt.value = true;
@@ -309,6 +347,15 @@ const confirmReservations = async () => {
     }
   } catch (err) {
     console.error("Erreur lors de la confirmation globale:", err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    analyticsService.capture("reservation_failed", {
+      session_id: session.value.id,
+      // Le conflit (section prise entre-temps) vient du message de
+      // reservationService.createBatchReservations.
+      reason: errorMessage.includes("déjà réservée") ? "conflict" : "error",
+      error_message: errorMessage,
+      source: "session_page",
+    });
     toast.errorFromException(
       err,
       err instanceof Error && err.message ? err.message : t("detailSession.reservationError"),
@@ -348,6 +395,12 @@ const cancelReservation = async (textStudyId: string, section?: number) => {
       if (session.value) {
         session.value.reservations = reservations.value;
       }
+
+      analyticsService.capture("reservation_cancelled", {
+        session_id: session.value?.id,
+        is_guest: currentUser.value == null,
+        source: "session_page",
+      });
     }
   } catch (err) {
     console.error("Erreur lors de l'annulation:", err);
@@ -373,6 +426,13 @@ const toggleReservationCompletion = async (textStudyId: string, section: number)
     );
 
     reservation.isCompleted = newCompletionStatus;
+
+    analyticsService.capture("section_marked_read", {
+      session_id: session.value.id,
+      marked: newCompletionStatus,
+      is_guest: currentUser.value == null,
+      source: "session",
+    });
   } catch (error) {
     console.error("Erreur lors de la mise à jour de la réservation:", error);
     toast.errorFromException(error, t("detailSession.updateError"));
@@ -401,6 +461,11 @@ const goToManagement = () => {
   if (session.value) {
     router.push(`/session-management/${session.value.id}`);
   }
+};
+
+const goToCreateChain = () => {
+  analyticsService.capture("create_chain_cta_clicked", { source: "session_detail" });
+  router.push("/share-reading");
 };
 
 const applySessionSeo = (s: typeof session.value) => {
@@ -433,6 +498,38 @@ onMounted(async () => {
   currentUser.value = await sessionService.getCurrentUser();
   await loadSessionData();
   applySessionSeo(session.value);
+
+  // Point d'entrée du funnel de réservation. Pas de nom de session dans les
+  // propriétés : les intitulés portent souvent des noms de personnes.
+  const s = session.value;
+  if (s) {
+    analyticsService.capture("session_viewed", {
+      session_id: s.id,
+      text_type: s.type,
+      is_ended: s.isEnded === true || s.isCompleted === true,
+      is_expired: s.dateLimit instanceof Date && s.dateLimit.getTime() < Date.now(),
+      sections_total: progressStats.value.total,
+      sections_reserved_pct: Math.round(progressStats.value.reservedPercentage),
+      participants_count: progressStats.value.participants,
+      is_authenticated: currentUser.value != null,
+    });
+  }
+});
+
+// La recherche et le filtre signalent une intention active de trouver une
+// section libre : trackés une fois (recherche) ou à chaque bascule (filtre).
+watch(searchTerm, (value) => {
+  if (!value.trim() || hasTrackedSearch) return;
+  hasTrackedSearch = true;
+  analyticsService.capture("session_search_used", { session_id: session.value?.id });
+});
+
+watch(showOnlyAvailable, (enabled) => {
+  analyticsService.capture("session_filter_toggled", {
+    session_id: session.value?.id,
+    filter: "available_only",
+    enabled,
+  });
 });
 
 watch(session, (s) => applySessionSeo(s));
@@ -560,7 +657,7 @@ watch(session, (s) => applySessionSeo(s));
           <p class="text-text-secondary max-w-xl mx-auto mb-6 leading-relaxed">
             {{ t("detailSession.createYourOwnText") }}
           </p>
-          <button @click="router.push('/share-reading')" class="btn btn-primary">
+          <button @click="goToCreateChain" class="btn btn-primary">
             <AppIcon name="plus" :size="16" />
             {{ t("detailSession.createYourOwnButton") }}
           </button>

--- a/src/views/ShareReading/NewSession.vue
+++ b/src/views/ShareReading/NewSession.vue
@@ -8,6 +8,7 @@ import { TextTypeService } from "../../services/textTypeService";
 import { authService } from "../../services/authService";
 import type { User } from "../../services/authService";
 import { seoService } from "../../services/seoService";
+import { analyticsService } from "../../services/analyticsService";
 import SignupPromptModal from "../../components/SignupPromptModal.vue";
 import AppIcon from "../../components/icons/AppIcon.vue";
 import { useToast } from "../../composables/useToast";
@@ -79,6 +80,10 @@ const formatBookName = (bookName: string) => {
 
 onMounted(async () => {
   currentUser.value = await authService.getCurrentUser();
+  // Entrée du funnel de création (session_created en est la sortie).
+  analyticsService.capture("session_create_started", {
+    is_authenticated: currentUser.value != null,
+  });
   if (!currentUser.value) {
     showAuthPrompt.value = true;
   }
@@ -129,12 +134,23 @@ const createSession = async () => {
       sessionData.guestEmailRequired,
     );
 
+    analyticsService.capture("session_created", {
+      session_id: sessionId,
+      text_type: sessionData.type,
+      books_count: selectedBooks.value.length,
+      guest_email_required: sessionData.guestEmailRequired,
+      deadline_days: Math.ceil(
+        (new Date(sessionData.dateLimit).getTime() - Date.now()) / (24 * 3600 * 1000),
+      ),
+    });
+
     // Le toast est monté au niveau de l'app : il survit à la redirection et
     // reste visible sur la page de la session nouvellement créée.
     toast.success(t("newSession.createdSuccess"));
     router.push(`/share-reading/session/${sessionId}`);
   } catch (error) {
     console.error("Erreur lors de la création de la session:", error);
+    analyticsService.captureException(error, { flow: "session_create" });
     message.value = t("newSession.createError");
     messageType.value = "error";
     isLoading.value = false;

--- a/src/views/ShareReading/ShareHomePage.vue
+++ b/src/views/ShareReading/ShareHomePage.vue
@@ -11,6 +11,7 @@ import AccountCta from "../../components/AccountCta.vue";
 import AppIcon from "../../components/icons/AppIcon.vue";
 import { seoService } from "../../services/seoService";
 import { authService } from "../../services/authService";
+import { analyticsService } from "../../services/analyticsService";
 import { isNativeApp } from "../../composables/useNativeApp";
 
 const router = useRouter();
@@ -168,6 +169,10 @@ const handleSessionClick = (session: Session) => {
 
 // Logged-in users go straight to the form; visitors get the sign-in prompt.
 const handleCreateClick = () => {
+  analyticsService.capture("create_chain_cta_clicked", {
+    source: "share_home",
+    is_authenticated: isAuthenticated.value,
+  });
   if (isAuthenticated.value) {
     router.push("/share-reading/new-session");
   } else {

--- a/src/views/StudyPage.vue
+++ b/src/views/StudyPage.vue
@@ -20,6 +20,7 @@ import {
 } from "../services/offlineLibraryService";
 import { ensureManifestLoaded } from "../services/offlineTextStore";
 import { useToast } from "../composables/useToast";
+import { analyticsService } from "../services/analyticsService";
 import AppIcon from "../components/icons/AppIcon.vue";
 import AccountCta from "../components/AccountCta.vue";
 
@@ -42,8 +43,12 @@ async function toggleDownload(text: TextStudyJsonEntry) {
   try {
     if (isBookDownloaded(book)) {
       await removeBook(book);
+      analyticsService.capture("offline_download_deleted", { scope: "book", book: book.path });
     } else {
       await downloadBook(book);
+      // Téléchargements déclenchés par l'utilisateur uniquement (la synchro en
+      // arrière-plan de la lecture du jour n'est pas trackée).
+      analyticsService.capture("offline_download_completed", { scope: "book", book: book.path });
     }
   } catch {
     toast.error(t("downloads.error"));
@@ -108,6 +113,11 @@ const tabAllDownloaded = computed(
 );
 
 async function downloadAllInTab() {
+  analyticsService.capture("offline_download_started", {
+    scope: "all",
+    tab: selectedType.value,
+    books_count: tabBooks.value.filter((b) => !isBookDownloaded(b)).length,
+  });
   for (const book of tabBooks.value) {
     if (isBookDownloaded(book)) continue;
     try {
@@ -117,6 +127,7 @@ async function downloadAllInTab() {
       return; // Probablement hors connexion : inutile d'enchaîner les échecs.
     }
   }
+  analyticsService.capture("offline_download_completed", { scope: "all", tab: selectedType.value });
 }
 
 function formatSize(bytes: number): string {

--- a/src/views/TextReading/TextReadingPage.vue
+++ b/src/views/TextReading/TextReadingPage.vue
@@ -33,6 +33,7 @@ import AppIcon from "../../components/icons/AppIcon.vue";
 import { useToast } from "../../composables/useToast";
 import { useReadingSize } from "../../composables/useReadingSize";
 import { isNativeApp } from "../../composables/useNativeApp";
+import { analyticsService } from "../../services/analyticsService";
 
 const route = useRoute();
 const router = useRouter();
@@ -72,6 +73,12 @@ const error = ref(false);
 const content = ref<TextContent | null>(null);
 const showPhonetic = ref(false);
 
+// La translittération phonétique est une aide de lecture peu visible : mesurer
+// si elle est trouvée et utilisée.
+watch(showPhonetic, (enabled) => {
+  analyticsService.capture("phonetic_toggled", { enabled });
+});
+
 // --- Reading ---
 const isSingleSection = computed(() => content.value?.sections.length === 1);
 
@@ -102,6 +109,13 @@ const hasNext = computed(
 
 async function loadContent() {
   if (!textEntry.value) return;
+  // Usage de la bibliothèque vs lecture dans le cadre d'une chaîne.
+  analyticsService.capture("text_opened", {
+    text_id: textEntry.value.id,
+    corpus: textEntry.value.type,
+    book: textEntry.value.livre,
+    source: sessionSlug.value ? "session" : "library",
+  });
   loading.value = true;
   error.value = false;
   missingFile.value = false;
@@ -230,10 +244,21 @@ const isMine = computed(() => {
 
 async function reserve() {
   if (!session.value || reservationUnit.value === undefined) return;
+  analyticsService.capture("reservation_confirm_clicked", {
+    session_id: session.value.id,
+    sections_count: 1,
+    is_guest: currentUser.value == null,
+    source: "reading_page",
+  });
   if (
     !currentUser.value &&
     (!reservationForm.value.name || (guestEmailRequired.value && !reservationForm.value.email))
   ) {
+    analyticsService.capture("reservation_failed", {
+      session_id: session.value.id,
+      reason: !reservationForm.value.name ? "missing_name" : "missing_email",
+      source: "reading_page",
+    });
     toast.info(guestIntroText.value);
     return;
   }
@@ -255,8 +280,23 @@ async function reserve() {
       reservationForm.value,
     );
     session.value.reservations = [...session.value.reservations, local];
+    analyticsService.capture("reservation_completed", {
+      session_id: session.value.id,
+      text_type: session.value.type,
+      sections_count: 1,
+      is_guest: currentUser.value == null,
+      guest_has_email: currentUser.value == null && reservationForm.value.email.trim() !== "",
+      source: "reading_page",
+    });
     toast.success(t("textReading.reserveSuccess"));
   } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    analyticsService.capture("reservation_failed", {
+      session_id: session.value.id,
+      reason: errorMessage.includes("déjà réservée") ? "conflict" : "error",
+      error_message: errorMessage,
+      source: "reading_page",
+    });
     toast.errorFromException(
       e,
       e instanceof Error && e.message ? e.message : t("textReading.reserveError"),
@@ -274,6 +314,11 @@ async function cancelReservation() {
   try {
     await sessionService.deleteReservation(session.value.id, r.id);
     session.value.reservations = session.value.reservations.filter((x) => x.id !== r.id);
+    analyticsService.capture("reservation_cancelled", {
+      session_id: session.value.id,
+      is_guest: currentUser.value == null,
+      source: "reading_page",
+    });
   } catch (e) {
     toast.errorFromException(e, t("textReading.cancelError"));
   } finally {
@@ -290,6 +335,12 @@ async function toggleRead() {
     await sessionService.markReservationAsCompleted(session.value.id, r.id, next);
     r.isCompleted = next;
     session.value.reservations = [...session.value.reservations];
+    analyticsService.capture("section_marked_read", {
+      session_id: session.value.id,
+      marked: next,
+      is_guest: currentUser.value == null,
+      source: "reading_page",
+    });
   } catch (e) {
     toast.errorFromException(e, t("textReading.updateError"));
   } finally {

--- a/src/views/profilePage/DailyReading.vue
+++ b/src/views/profilePage/DailyReading.vue
@@ -10,6 +10,7 @@ import { sessionService } from "../../services/sessionService";
 import { appendHebrewNumeral } from "../../services/hebrewNumerals";
 import { isNativeApp } from "../../composables/useNativeApp";
 import { useToast } from "../../composables/useToast";
+import { analyticsService } from "../../services/analyticsService";
 import DailyReadingItem from "./DailyReadingItem.vue";
 import ReminderTimeModal from "./ReminderTimeModal.vue";
 import AppIcon from "../../components/icons/AppIcon.vue";
@@ -122,7 +123,8 @@ function isSelected(id: string | number): boolean {
 
 async function toggleSelect(entry: TextStudyJsonEntry) {
   const id = String(entry.id);
-  if (selectedIds.value.includes(id)) {
+  const removed = selectedIds.value.includes(id);
+  if (removed) {
     selectedIds.value = selectedIds.value.filter((x) => x !== id);
     const next = new Set(completedIds.value);
     next.delete(id);
@@ -132,6 +134,10 @@ async function toggleSelect(entry: TextStudyJsonEntry) {
     selectedIds.value = [...selectedIds.value, id];
   }
   await persistSelection();
+  analyticsService.capture("daily_reading_configured", {
+    action: removed ? "removed" : "added",
+    texts_count: selectedIds.value.length,
+  });
 }
 
 async function toggleCompleted(id: string) {
@@ -143,6 +149,12 @@ async function toggleCompleted(id: string) {
   // Marking read folds the text away; un-marking reopens it to keep reading.
   setCollapsed(id, nowRead);
   await persistProgress();
+  analyticsService.capture("daily_reading_marked_read", {
+    marked: nowRead,
+    done_count: completedCount.value,
+    total_count: totalCount.value,
+    all_done: allDone.value,
+  });
 }
 
 function setCollapsed(id: string, collapsed: boolean) {
@@ -187,11 +199,14 @@ async function enableReminder(time: { hour: number; minute: number }) {
     reminderEnabled.value = true;
     reminderHour.value = time.hour;
     reminderMinute.value = time.minute;
+    analyticsService.capture("reminder_enabled", { hour: time.hour, minute: time.minute });
     toast.success(
       t("notifications.enabledToast", { time: formatReminderTime(time.hour, time.minute) }),
     );
   } catch (e: unknown) {
     if (e instanceof Error && e.message === "PERMISSION_DENIED") {
+      // Friction push : l'utilisateur voulait le rappel mais l'OS a dit non.
+      analyticsService.capture("reminder_enable_failed", { reason: "permission_denied" });
       toast.error(t("notifications.permissionDenied"));
     } else {
       console.error("Activation du rappel échouée:", e);
@@ -207,6 +222,7 @@ async function disableReminder() {
   try {
     await pushService.disable(props.userId);
     reminderEnabled.value = false;
+    analyticsService.capture("reminder_disabled");
     toast.success(t("notifications.disabledToast"));
   } catch (e: unknown) {
     console.error("Désactivation du rappel échouée:", e);


### PR DESCRIPTION
## Quoi

Ajout d'environ 25 événements produit derrière la façade `analyticsService` (conventions snake_case au passé), pour instrumenter les deux parcours clés et les hypothèses produit :

- **Funnel chaîne partagée** (`DetailSession` + `TextReadingPage`) : `session_viewed` → `session_section_selected` → `reservation_confirm_clicked` → `reservation_completed`, avec `reservation_failed {reason: missing_name | missing_email | conflict | error}`, `reservation_cancelled`, `section_marked_read`, recherche et filtre « disponibles ». La propriété `source` distingue la page session de la page de lecture.
- **Partage** (`ShareModal`) : `share_modal_opened`, `share_channel_selected {channel, content_type}` (WhatsApp, SMS, Facebook, copie ; chaîne vs chiour).
- **Conversion invité → compte** : `signup_prompt_shown/clicked {variant, action}` dans la modale, `guest_reservations_migrated {migrated_count}` à la migration des réservations invité.
- **Retour visiteur** : `home_viewed {variant: landing | dashboard}`, `home_card_clicked {card}`, `create_chain_cta_clicked {source}`, funnel `session_create_started` → `session_created`.
- **Profil & contenu** : `daily_reading_configured/marked_read`, `reminder_enabled/disabled/enable_failed`, `text_opened {corpus, source}`, `phonetic_toggled`, `chiour_played` + `chiour_progress {milestone: 25|50|75|100}`.
- **App native** : `offline_download_started/completed/deleted`, `push_notification_opened`.
- **Cycle de vie** : `signed_out`, `account_deleted`.

## Transverse

- `stampPlatform` (before_send) ajoute `is_logged_in` et `locale` à tous les événements, à côté de `app_platform`.
- Les événements émis depuis `/admin` et `/studio` sont supprimés (outils internes, ils pollueraient les stats).

## Pourquoi

Alimenter les 5 dashboards PostHog créés en parallèle (Funnel chaîne partagée, Conversion invité → compte, Acquisition & viralité, Rétention & retour, Engagement contenu, ids 855562 à 855566) pour trancher les hypothèses : profil peu utilisé, chaînes partagées mais peu réservées, comptes rarement créés, parcours mal compris.

## À savoir pour la review

- Événements « une fois par visite » (1re sélection, 1re recherche) : flags locaux dans `DetailSession` pour ne pas noyer les stats.
- La synchro offline en arrière-plan de la lecture du jour n'est volontairement pas trackée (seuls les téléchargements déclenchés par l'utilisateur le sont).
- Aucun nom de session dans les propriétés (les intitulés portent souvent des noms de personnes).
- `npm run verify` : type-check et lint OK ; le test `guestReservations.test.ts` échoue déjà sur `main` (environnement sans `localStorage`, corrigé dans une tâche séparée).
- Les données n'arriveront qu'après déploiement en prod (PostHog chargé en prod uniquement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)