### PR TITLE
Corriger le test localStorage de guestService sous Node 22+

### DIFF
--- a/src/__tests__/guestReservations.test.ts
+++ b/src/__tests__/guestReservations.test.ts
@@ -1,8 +1,26 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
 import type { TextStudyReservation } from "../models/models";
 import { EnumTypeTextStudy } from "../models/typeTextStudy";
 
 vi.mock("../services/firestoreService");
+
+// Node >= 22 expose un getter global `localStorage` (undefined sans
+// --localstorage-file) qui masque celui de jsdom, y compris via `window`
+// puisque vitest fusionne window et globalThis. Stub mémoire minimal pour
+// que la persistance reste testable.
+beforeAll(() => {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, String(value)),
+    removeItem: (key: string) => void store.delete(key),
+    clear: () => store.clear(),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  });
+});
 
 import { guestService } from "../services/guestService";
 import { reservationService } from "../services/reservationService";


### PR DESCRIPTION
## Quoi

Le test « crée un identifiant stable et le persiste en localStorage » de `src/__tests__/guestReservations.test.ts` échouait sur main avec `TypeError: Cannot read properties of undefined (reading 'getItem')`. Un `beforeAll` installe désormais, via `vi.stubGlobal`, un stub `localStorage` minimal adossé à une `Map` (getItem/setItem/removeItem/clear/key/length).

## Pourquoi

La config vitest déclare bien `environment: 'jsdom'`, mais Node ≥ 22 (v26 en local) expose son propre getter global expérimental `localStorage`, qui renvoie `undefined` tant que `--localstorage-file` n'est pas fourni (d'où l'`ExperimentalWarning` dans la sortie vitest). Comme la clé globale existe déjà, vitest ne recopie jamais le `localStorage` de jsdom par-dessus; et comme vitest fusionne `window` et `globalThis`, même `window.localStorage` retombe sur ce getter à `undefined`. `guestService` survivait grâce à son try/catch de repli mémoire, ce qui explique que seules les assertions directes sur `localStorage` échouaient.

## À savoir pour la revue

- Brancher le vrai `localStorage` de jsdom n'était pas possible : il est masqué lui aussi.
- Tout futur test lisant `localStorage` directement rencontrera le même masquage; si ça se reproduit, un setup file vitest global serait la solution durable.
- `npm run verify` passe à 100 % (109 tests, 11 fichiers, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)