### PR TITLE
Test perf : figer l'animation de lumière du mur

### DIFF
--- a/src/components/StoneWallBackground.vue
+++ b/src/components/StoneWallBackground.vue
@@ -17,8 +17,6 @@
    invalidate its cached render surface on modest GPUs, for a barely
    visible effect. */
 
-import { isLowEndDevice } from "../composables/useDevicePerf";
-
 const VIEW_W = 1600;
 const VIEW_H = 1100;
 
@@ -123,10 +121,10 @@ const grain = (() => {
 </script>
 
 <template>
-  <!-- Appareils modestes : la lumière reste figée (comme prefers-reduced-motion).
-       Même compositor-only, deux blobs animés en permanence derrière un mask
-       plein écran se paient en fluidité sur un vieux téléphone. -->
-  <div class="stone-wall" :class="{ 'stone-wall--static': isLowEndDevice }" aria-hidden="true">
+  <!-- Lumière figée pour tout le monde le temps de mesurer l'impact des blobs
+       animés sur les performances ; si le gain est confirmé, l'animation
+       reviendra derrière une préférence utilisateur. -->
+  <div class="stone-wall stone-wall--static" aria-hidden="true">
     <div class="stone-wall__wall">
       <div class="sw-grain" :style="{ backgroundImage: grain }" />
       <!-- The light behind the wall, seen through the mortar joints (full)


### PR DESCRIPTION
## Contexte

L'animation des deux blobs de lumière derrière le mur de pierre (StoneWallBackground) est suspectée de ralentir le site, même si elle est compositor-only. Cette PR fige la lumière pour tout le monde afin de mesurer son impact réel sur les performances.

## Changements

- Le mode statique (déjà appliqué aux appareils modestes et à `prefers-reduced-motion`) est désormais forcé pour tout le monde : les blobs restent affichés à opacité 0.4, sans animation.
- Le mur reste visible à l'identique, seule la dérive de la lumière est coupée.
- Tout le CSS d'animation est conservé pour pouvoir la réactiver facilement.

## Suite prévue

Si le gain de performance est confirmé, l'animation sera réintroduite derrière une option dans les préférences utilisateur.

## Vérifications

- `npm run type-check` OK
- Rendu vérifié en local : le mur s'affiche, les deux blobs ont `animation: none`

🤖 Generated with [Claude Code](https://claude.com/claude-code)