### PR TITLE
Socle de mesure PostHog fiable : périmètre, super propriétés, segmentation, chunks

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+/**
+ * Version applicative injectée au build par `define` (voir vite.config.ts).
+ * Toujours définie : Vite la remplace littéralement à la compilation, y
+ * compris pendant les tests (vitest.config.ts fusionne la config Vite).
+ */
+declare const __APP_VERSION__: string;

--- a/src/__tests__/analyticsAudience.test.ts
+++ b/src/__tests__/analyticsAudience.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveUserType } from "../config/analyticsAudience";
+
+describe("resolveUserType (person property user_type)", () => {
+  it("classe l'équipe en interne", () => {
+    expect(resolveUserType("admin@phenixel.fr")).toBe("internal");
+    expect(resolveUserType("contact.phenixel@gmail.com")).toBe("internal");
+  });
+
+  it("isole le compte de démonstration remis à Google", () => {
+    expect(resolveUserType("testeur@exemple.com")).toBe("google_review");
+  });
+
+  it("reconnaît les testeurs du test fermé", () => {
+    expect(resolveUserType("milkshake.2734@gmail.com")).toBe("tester");
+  });
+
+  it("considère tout compte inconnu comme un vrai utilisateur", () => {
+    expect(resolveUserType("quelquun@example.com")).toBe("real");
+    expect(resolveUserType("")).toBe("real");
+    expect(resolveUserType(null)).toBe("real");
+    expect(resolveUserType(undefined)).toBe("real");
+  });
+
+  it("ignore la casse et les espaces (Firebase renvoie l'email tel que saisi)", () => {
+    expect(resolveUserType("  Admin@Phenixel.FR ")).toBe("internal");
+  });
+});

--- a/src/config/analyticsAudience.ts
+++ b/src/config/analyticsAudience.ts
@@ -1,0 +1,45 @@
+/**
+ * Segmentation des comptes dans PostHog (person property `user_type`).
+ *
+ * Tant que l'app est en test fermé, les stats produit sont noyées par nos
+ * propres comptes : dev, testeurs invités, et le compte de démonstration
+ * fourni à Google pour la review du Play Store. `user_type` est posé au
+ * moment de l'identification (analyticsService.identify) et permet de les
+ * exclure d'un clic dans les insights et les cohortes.
+ *
+ * ⚠️ C'EST CE FICHIER QU'ON ÉDITE quand un testeur arrive ou s'en va :
+ * ajouter l'email dans la bonne liste, rien d'autre à toucher. Les emails
+ * sont comparés en minuscules, sans espaces autour.
+ *
+ * Attention : la propriété ne vaut que pour les personnes CONNECTÉES. Un
+ * appareil qui navigue sans compte (le device de review Google avant login,
+ * par exemple) reste une personne anonyme non taguable ; pour ces cas, le
+ * filtre fiable côté insight reste `$host = 'petite-jerusalem.fr'`.
+ */
+
+export type UserType = "internal" | "google_review" | "tester" | "real";
+
+/** L'équipe : comptes de développement et d'administration. */
+export const INTERNAL_EMAILS = ["admin@phenixel.fr", "contact.phenixel@gmail.com"];
+
+/** Compte de démonstration remis à Google pour la review du Play Store. */
+export const GOOGLE_REVIEW_EMAILS = ["testeur@exemple.com"];
+
+/** Testeurs externes du test fermé (liste à compléter au fil des invitations). */
+export const TESTER_EMAILS = ["milkshake.2734@gmail.com"];
+
+function normalize(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+const BY_EMAIL = new Map<string, UserType>([
+  ...INTERNAL_EMAILS.map((email) => [normalize(email), "internal"] as const),
+  ...GOOGLE_REVIEW_EMAILS.map((email) => [normalize(email), "google_review"] as const),
+  ...TESTER_EMAILS.map((email) => [normalize(email), "tester"] as const),
+]);
+
+/** Tout compte inconnu de ces listes est un vrai utilisateur. */
+export function resolveUserType(email: string | null | undefined): UserType {
+  if (!email) return "real";
+  return BY_EMAIL.get(normalize(email)) ?? "real";
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,16 +20,72 @@ if (isNativeApp) {
 
 // Après un déploiement, les chunks lazy-loadés changent de hash : un onglet
 // resté ouvert sur l'ancienne version obtient un 404 en naviguant (« Failed to
-// fetch dynamically imported module ») et la page reste blanche. On recharge
-// une seule fois (garde sessionStorage pour ne pas boucler si le réseau est
-// vraiment en panne) : le HTML frais référence les nouveaux chunks.
+// fetch dynamically imported module ») et la navigation échoue, page blanche à
+// la clé. On recharge une seule fois (garde sessionStorage pour ne pas boucler
+// si le réseau est vraiment en panne) : le HTML frais référence les nouveaux
+// chunks.
+//
+// Trois sources d'écoute, parce qu'elles ne se recouvrent pas :
+//  - vite:preloadError — échec du PRÉchargement des dépendances d'un chunk ;
+//  - router.onError — échec de l'import() du composant de route lui-même, qui
+//    ne déclenche aucun vite:preloadError. C'est le cas réellement observé en
+//    production, et il n'était pas rattrapé ;
+//  - unhandledrejection — les import() hors routeur (services, composants).
+const CHUNK_RELOAD_KEY = "pj_chunk_reload_at";
+
+// Messages des navigateurs pour un module dynamique injoignable : Chrome
+// (« Failed to fetch dynamically imported module »), Firefox (« error loading
+// dynamically imported module »), Safari (« Importing a module script failed »).
+const CHUNK_ERROR = /dynamically imported module|Importing a module script failed/i;
+
+function chunkNameFrom(message: string): string | null {
+  const url = message.match(/https?:\/\/\S+?\.(?:js|mjs|css)/)?.[0];
+  return url ? (url.split("/").pop() ?? null) : null;
+}
+
+/** Un seul rechargement par minute et par onglet : sinon un vrai incident réseau boucle. */
+function claimReload(): boolean {
+  try {
+    const lastReload = Number(sessionStorage.getItem(CHUNK_RELOAD_KEY) ?? 0);
+    if (Date.now() - lastReload < 60_000) return false;
+    sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()));
+  } catch {
+    // Stockage indisponible : on recharge quand même, sans garde.
+  }
+  return true;
+}
+
+/** Renvoie true si l'erreur est bien un chunk manquant ET qu'on recharge. */
+function handleChunkLoadError(error: unknown, source: string): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!CHUNK_ERROR.test(message)) return false;
+
+  const reloading = claimReload();
+  // Capture AVANT le rechargement : PostHog vide sa file en sendBeacon au
+  // pagehide déclenché par reload(), l'événement n'est donc pas perdu.
+  void import("./services/analyticsService")
+    .then(({ analyticsService }) =>
+      analyticsService.capture("chunk_load_error", {
+        chunk: chunkNameFrom(message),
+        route: window.location.pathname,
+        source,
+        reloaded: reloading,
+      }),
+    )
+    .finally(() => {
+      if (reloading) window.location.reload();
+    });
+  return reloading;
+}
+
 window.addEventListener("vite:preloadError", (event) => {
-  const RELOAD_KEY = "pj_chunk_reload_at";
-  const lastReload = Number(sessionStorage.getItem(RELOAD_KEY) ?? 0);
-  if (Date.now() - lastReload < 60_000) return;
-  sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
-  event.preventDefault();
-  window.location.reload();
+  // On n'étouffe l'erreur que si on la traite : au 2e échec d'affilée, elle
+  // doit redevenir visible (Error tracking) plutôt que disparaître.
+  if (handleChunkLoadError(event.payload, "vite_preload")) event.preventDefault();
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+  handleChunkLoadError(event.reason, "unhandled_rejection");
 });
 
 const app = createApp(App);
@@ -51,6 +107,12 @@ app.directive("click-outside", {
 
 app.use(router);
 app.use(i18n);
+
+// Le composant de route est importé APRÈS les gardes et AVANT que l'URL ne
+// change : quand son chunk a disparu (déploiement), l'échec remonte ici, pas
+// dans vite:preloadError, et l'utilisateur reste bloqué sur la page de départ
+// sans rien voir. C'est exactement ce qui s'est produit en prod le 28/07.
+router.onError((error) => handleChunkLoadError(error, "router"));
 
 // Les erreurs de rendu/handlers Vue ne remontent pas jusqu'à window.onerror :
 // sans ce handler, elles seraient invisibles dans l'Error tracking PostHog.

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -3,6 +3,7 @@ import { watch } from "vue";
 import { appPlatform, isNativeApp } from "../composables/useNativeApp";
 import { isDegradedRendering } from "../composables/useDevicePerf";
 import { getConsentChoice, onConsentChange } from "../composables/useConsent";
+import { resolveUserType } from "../config/analyticsAudience";
 import { i18n } from "../i18n";
 import type { User } from "../models/models";
 
@@ -244,7 +245,13 @@ class AnalyticsService {
 
   /** À la connexion : rattache les événements au compte (id Firebase). */
   identify(user: User): void {
-    this.posthog?.identify(user.id, { email: user.email, name: user.name });
+    if (!this.posthog) return;
+    this.posthog.identify(user.id, { email: user.email, name: user.name });
+    // Segmentation interne / testeur / vrai utilisateur (voir la liste dans
+    // config/analyticsAudience.ts). Posée à chaque identification, pas
+    // seulement à la création du profil : une liste éditée doit se propager
+    // aux comptes déjà connus dès leur prochaine session.
+    this.posthog.setPersonProperties({ user_type: resolveUserType(user.email) });
   }
 
   /**

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -9,9 +9,10 @@ import type { User } from "../models/models";
 /**
  * Suivi produit et traque d'erreurs via PostHog (instance EU).
  *
- * - Chargé uniquement en production, par import dynamique : le SDK ne rentre
- *   pas dans le bundle initial et ne bloque jamais le démarrage (même schéma
- *   que Firebase Analytics dans firebase.ts).
+ * - Chargé uniquement sur les surfaces de production (voir isTrackedSurface),
+ *   par import dynamique : le SDK ne rentre pas dans le bundle initial et ne
+ *   bloque jamais le démarrage (même schéma que Firebase Analytics dans
+ *   firebase.ts).
  * - La clé du projet est publique (elle part dans le bundle, comme la config
  *   Firebase) : ce n'est pas un secret.
  * - Tant que PostHog n'est pas chargé (dev, adblock, échec réseau), toutes les
@@ -22,6 +23,61 @@ import type { User } from "../models/models";
 // Clé publique du projet PostHog (project settings → Project API key).
 const POSTHOG_KEY = "phc_qV5GtjgB46gGmPGpXq8edRXRK94jmgGkiNLdFA6tyRSW";
 const POSTHOG_HOST = "https://eu.i.posthog.com";
+
+/**
+ * Hôtes web considérés comme de la production. Tout le reste (localhost,
+ * `npm run preview` sur :4173, canaux de preview Firebase en
+ * `petite-jerusalem-dev--pr*.web.app`) envoyait ses événements dans le même
+ * projet et faussait les stats : sur 14 jours, la preview d'une seule PR
+ * pesait 184 événements, 4e hôte en volume.
+ */
+const PRODUCTION_HOSTS = ["petite-jerusalem.fr", "www.petite-jerusalem.fr"];
+
+/**
+ * Porte de sortie manuelle : `localStorage.setItem('ph_debug', '1')` force le
+ * chargement de PostHog n'importe où (dev, preview), pour vérifier une
+ * instrumentation avant de la déployer. Les événements partent alors avec
+ * `env: 'preview'`, ce qui permet de les exclure de toutes les analyses.
+ */
+const DEBUG_STORAGE_KEY = "ph_debug";
+
+function isDebugOverride(): boolean {
+  try {
+    return localStorage.getItem(DEBUG_STORAGE_KEY) === "1";
+  } catch {
+    // Stockage indisponible (mode restreint) : pas de débogage forcé.
+    return false;
+  }
+}
+
+/**
+ * Vraie surface de production : le site public, ou l'app native.
+ *
+ * L'app ne peut pas être reconnue à son hôte : la webview Capacitor sert le
+ * bundle depuis `https://localhost` (c'est `stampPlatform` qui réécrit ensuite
+ * le `$host` des événements en `app.android` / `app.ios`). Le seul signal
+ * fiable au moment de l'init est donc `isNativeApp`.
+ */
+function isProductionSurface(): boolean {
+  return isNativeApp || PRODUCTION_HOSTS.includes(window.location.hostname);
+}
+
+function isTrackedSurface(): boolean {
+  if (isDebugOverride()) return true;
+  // `npm run dev` : jamais de suivi automatique, même sur un hôte de prod.
+  if (!import.meta.env.PROD) return false;
+  return isProductionSurface();
+}
+
+/** Super propriétés (A2) : contexte de release attaché à chaque événement. */
+const APP_ENV = isProductionSurface() ? "production" : "preview";
+const APP_VERSION = __APP_VERSION__;
+
+const SUPER_PROPERTIES = {
+  env: APP_ENV,
+  app_platform: appPlatform,
+  app_version: APP_VERSION,
+} as const;
 
 /**
  * Dans l'app, la webview Capacitor sert le bundle depuis `https://localhost` :
@@ -48,13 +104,15 @@ function rewriteNativeUrls(bag: Properties | undefined): void {
 }
 
 /**
- * Estampille chaque événement avec la plateforme d'exécution.
+ * Estampille chaque événement avec le contexte de release (env, plateforme,
+ * version) et l'état de la session.
  *
- * Passe par `before_send` plutôt que par `posthog.register()` : les super
+ * Double ceinture avec le `posthog.register()` de load() : les super
  * propriétés ne couvrent ni le `$pageview` initial (capturé pendant `init()`,
- * donc avant tout `register()`), ni les événements qui suivent un `reset()`
- * de déconnexion, qui vide la persistance. `before_send` s'applique à tout,
- * y compris aux `$exception` d'Error tracking.
+ * donc avant que la ligne suivante ne s'exécute), ni les événements qui
+ * suivent un `reset()` de déconnexion, qui vide la persistance. `before_send`
+ * s'applique à tout, y compris aux `$exception` d'Error tracking. Les deux
+ * écrivent les mêmes valeurs : aucun conflit possible.
  */
 /**
  * Le backoffice admin et le studio auteurs sont des outils internes : leurs
@@ -65,7 +123,7 @@ const INTERNAL_PATHS = /^\/(admin|studio)(\/|$)/;
 const stampPlatform: BeforeSendFn = (event) => {
   if (!event) return event;
   if (INTERNAL_PATHS.test(window.location.pathname)) return null;
-  event.properties.app_platform = appPlatform;
+  Object.assign(event.properties, SUPER_PROPERTIES);
   // Segmentation anonyme/connecté et par langue sur tous les événements, y
   // compris les $pageview automatiques (mêmes raisons que app_platform).
   event.properties.is_logged_in = isLoggedIn;
@@ -92,7 +150,7 @@ class AnalyticsService {
    * la capture ; un nouvel accord la réactive.
    */
   init(): void {
-    if (!import.meta.env.PROD || !POSTHOG_KEY) return;
+    if (!POSTHOG_KEY || !isTrackedSurface()) return;
     if (getConsentChoice() === "granted") {
       void this.load();
     }
@@ -142,6 +200,12 @@ class AnalyticsService {
         // Plateforme + URL lisible sur chaque événement (voir stampPlatform).
         before_send: stampPlatform,
       });
+      // MÊME TICK que init(), impérativement : pas de useEffect, pas de
+      // callback async, pas d'await entre les deux. Un register() différé
+      // laisse partir les premiers événements sans les propriétés (écarts déjà
+      // mesurés de 47 ms à 30 s, et des sessions courtes entièrement non
+      // taguées). `stampPlatform` rattrape le reste — voir son commentaire.
+      posthog.register(SUPER_PROPERTIES);
       this.posthog = posthog;
 
       // Dégradation détectée APRÈS le chargement (sonde FPS de useDevicePerf) :

--- a/src/views/ShareReading/DetailSession.vue
+++ b/src/views/ShareReading/DetailSession.vue
@@ -61,6 +61,17 @@ const trackFirstSelection = () => {
     session_id: session.value?.id,
     is_authenticated: currentUser.value != null,
   });
+  // Entrée du funnel de réservation : sur cette page, cocher une première
+  // section EST l'ouverture du flux (la barre de confirmation apparaît).
+  // session_section_selected reste l'événement d'usage de la page ;
+  // reservation_started est l'étape de funnel, commune avec la page de lecture.
+  analyticsService.capture("reservation_started", {
+    session_id: session.value?.id,
+    text_type: session.value?.type,
+    sections_count: selectedItems.value.size,
+    is_guest: currentUser.value == null,
+    source: "session_page",
+  });
 };
 
 const groupedTextStudies = computed(() => {

--- a/src/views/TextReading/TextReadingPage.vue
+++ b/src/views/TextReading/TextReadingPage.vue
@@ -261,6 +261,31 @@ const isMine = computed(() => {
   return !!r && sessionService.canUserDeleteReservation(r, currentUser.value, reservationForm.value.email);
 });
 
+// Entrée du funnel de réservation : le lecteur atteint une section libre et la
+// barre de réservation s'affiche. C'était le pas manquant entre session_viewed
+// et reservation_confirm_clicked — le trou de conversion à mesurer est là,
+// entre voir le formulaire et cliquer sur « Confirmer ».
+const canReserveNow = computed(() => showReservationBar.value && !reservedStatus.value.isReserved);
+
+// Une seule fois par unité réservable : la navigation latérale entre textes
+// (goToText) ne recrée pas le composant, et le formulaire invité fait changer
+// les computeds à chaque frappe.
+let lastReservationStartKey: string | null = null;
+
+watch([canReserveNow, reservationUnit], ([canReserve, unit]) => {
+  if (!canReserve || !session.value) return;
+  const key = `${session.value.id}#${textId.value}#${unit}`;
+  if (lastReservationStartKey === key) return;
+  lastReservationStartKey = key;
+  analyticsService.capture("reservation_started", {
+    session_id: session.value.id,
+    text_type: session.value.type,
+    sections_count: 1,
+    is_guest: currentUser.value == null,
+    source: "reading_page",
+  });
+});
+
 async function reserve() {
   if (!session.value || reservationUnit.value === undefined) return;
   analyticsService.capture("reservation_confirm_clicked", {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,48 @@
 import { fileURLToPath, URL } from 'node:url'
+import { execFileSync } from 'node:child_process'
+import { createRequire } from 'node:module'
 
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 import tailwindcss from '@tailwindcss/vite'
 
+/**
+ * Version applicative figée dans le bundle (super propriété PostHog
+ * `app_version`, et rien d'autre pour l'instant). Sans elle, impossible de
+ * rattacher une erreur ou une régression à une release précise : c'est le
+ * breakdown des tuiles d'erreurs du dashboard produit.
+ *
+ * Repli, du plus fiable au plus dégradé :
+ *  1. APP_VERSION — override explicite (build de test, CI maison)
+ *  2. tag Git du build de release — deploy.yml et deploy-android.yml sont
+ *     déclenchés par un push de tag vX.Y.Z, que GitHub expose dans
+ *     GITHUB_REF_NAME (le checkout y est superficiel : `git describe` ne
+ *     retrouverait rien)
+ *  3. `git describe` — dev local et canaux de preview (dernier tag + nombre
+ *     de commits depuis, ex. v3.3.4-7-gabc1234)
+ *  4. version du package.json — dernier recours (clone sans historique Git)
+ */
+function resolveAppVersion(): string {
+  if (process.env.APP_VERSION) return process.env.APP_VERSION
+  if (process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME) {
+    return process.env.GITHUB_REF_NAME
+  }
+  try {
+    return execFileSync('git', ['describe', '--tags', '--always'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    }).trim()
+  } catch {
+    return createRequire(import.meta.url)('./package.json').version
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(resolveAppVersion()),
+  },
   // Port dédié à ce projet pour pouvoir bosser sur plusieurs projets en
   // parallèle sans collision avec le 5173 par défaut de Vite.
   server: {


### PR DESCRIPTION
Corrige les 3 problèmes de mesure et le bug applicatif relevés par l'analyse des 14 derniers jours.

## Périmètre et super propriétés (`e43482c`)

PostHog s'initialisait dès qu'un build de prod tournait, où qu'il tourne : `localhost:4173` et les canaux de preview Firebase envoyaient leurs événements dans le projet de production (la preview de la PR 125 pesait 184 événements, 4e hôte en volume). L'init est désormais réservée au site public et à l'app native.

L'app **ne peut pas** être reconnue à son hôte : la webview Capacitor sert le bundle depuis `https://localhost`, c'est `stampPlatform` qui réécrit ensuite le `$host` en `app.android`. Le gate s'appuie donc sur `isNativeApp`. `localStorage.ph_debug = '1'` reste une porte de sortie pour déboguer ailleurs (événements alors taggés `env: 'preview'`).

`env` / `app_platform` / `app_version` sont posées par un `register()` dans le **même tick** que `init()`, et répétées dans `before_send` — seul chemin qui couvre le `$pageview` capturé pendant `init()` et les événements post-`reset()`. `app_version` n'existait pas : injectée au build depuis le tag Git (`GITHUB_REF_NAME` sur les workflows de release, `git describe` en local, `package.json` en dernier recours).

## `reservation_started` (`e2ee14d`)

L'entonnoir s'ouvrait sur `reservation_confirm_clicked` : impossible de mesurer combien de lecteurs voient le formulaire sans le confirmer. L'événement est émis à l'ouverture du flux sur les deux pages concernées, dédupliqué pour ne pas compter chaque clic de chapitre.

À noter : `session_created` **existait déjà** et n'a pas de bug. Il est absent de la taxonomie parce qu'aucune session n'a été créée depuis le déploiement de l'instrumentation (3 `session_create_started`, 0 création, aucune exception `flow: session_create`).

## `user_type` (`5eed34b`)

Person property posée à chaque connexion (`internal` / `google_review` / `tester` / `real`), listes d'emails éditables dans un seul fichier commenté. Alimente les cohortes Interne / Testeurs / Vrais utilisateurs côté PostHog.

## `chunk_load_error` (`5d7672a`)

Un lazy chunk absent après déploiement remontait par trois chemins, dont un seul était traité. `vite:preloadError` ne couvre que le préchargement des dépendances ; l'échec de l'`import()` du composant de route part dans `router.onError`, qui n'était branché nulle part — la navigation avortait sans rien changer à l'écran.

C'est ce qui s'est produit le 28/07 sur `AdminChiourimPage` : deux échecs à 1,6 s d'intervalle, soit deux clics sans effet.

**L'arborescence admin n'a jamais fui dans le bundle public.** Vérifié sur le build actuel et sur v3.3.1 (la version live au moment de l'erreur) : aucun chunk public n'importe `Admin/*`, et une visite anonyme de `/admin/chiourim` ne requête pas le chunk — la garde `beforeEach` s'exécute avant la résolution du composant. Les deux exceptions venaient d'`admin@phenixel.fr` cliquant le lien admin depuis une page publique ; vue-router ne change l'URL qu'**après** le chargement du composant, d'où un `$current_url` public trompeur.

Les trois sources passent maintenant par le même traitement : capture de `chunk_load_error` (chunk, route, source) puis rechargement unique gardé par `sessionStorage`. L'erreur n'est étouffée que si elle est traitée : au 2e échec elle redevient visible dans Error tracking.

## Côté PostHog (déjà en place)

- Cohortes Interne (195997), Testeurs (195998), Vrais utilisateurs (195999) — email en dur `OR` `user_type`, pour qu'elles marchent avant et après ce déploiement.
- Dashboard « Produit — vrais utilisateurs » (858905), 5 tuiles filtrées `$host = 'petite-jerusalem.fr'`. Deux tuiles resteront vides jusqu'au déploiement de cette branche : l'étape `reservation_started` de l'entonnoir et le breakdown `app_version` des erreurs.

## Vérifications

`npm run verify` passe (114 tests, dont 5 nouveaux sur `resolveUserType`). Vérifié en préview locale : consentement accordé sans `ph_debug` → SDK non chargé ; avec `ph_debug` → SDK chargé et super propriétés persistées (`env: "preview"`, `app_platform: "web"`, `app_version: "v3.3.4-3-g5eed34b"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)