### PR TITLE
Mesurer les étapes manquantes du funnel de réservation

### DIFF
--- a/src/components/GuestForm.vue
+++ b/src/components/GuestForm.vue
@@ -19,6 +19,11 @@ interface Props {
 
 interface Emits {
   (e: "update:reservationForm", value: { name: string; email: string }): void;
+  // Première frappe réelle dans le formulaire. Le composant ne capture rien
+  // lui-même : il sert aussi la page de gestion (le propriétaire saisit un
+  // invité à la main), qui n'a rien à voir avec le funnel de réservation.
+  // Chaque page décide donc si ce signal l'intéresse.
+  (e: "firstInput", field: "name" | "email"): void;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -32,11 +37,17 @@ const emit = defineEmits<Emits>();
 const emailFieldRevealed = ref(false);
 const showEmailField = computed(() => props.emailRequired || emailFieldRevealed.value);
 
+let hasEmittedFirstInput = false;
+
 const updateField = (field: "name" | "email", value: string) => {
   emit("update:reservationForm", {
     ...props.reservationForm,
     [field]: value,
   });
+  if (!hasEmittedFirstInput && value.trim()) {
+    hasEmittedFirstInput = true;
+    emit("firstInput", field);
+  }
 };
 </script>
 

--- a/src/views/ShareReading/DetailSession.vue
+++ b/src/views/ShareReading/DetailSession.vue
@@ -53,6 +53,51 @@ const showSignupPrompt = ref(false);
 // la 1re recherche, sinon chaque clic de chapitre noierait les stats.
 let hasTrackedSelection = false;
 let hasTrackedSearch = false;
+let hasTrackedExpansion = false;
+let hasTrackedGuestForm = false;
+
+/**
+ * Étape manquante entre « voir la chaîne » et « cocher une section » : sur un
+ * texte à plusieurs chapitres, il faut d'abord le déplier. Sans cet événement,
+ * impossible de distinguer « n'a jamais ouvert un texte » (l'interaction n'est
+ * pas comprise) de « a ouvert et n'a rien coché » (plus rien de libre, ou
+ * hésitation).
+ */
+const trackTextExpanded = (textStudyId: string) => {
+  if (hasTrackedExpansion) return;
+  hasTrackedExpansion = true;
+  const index = textStudies.value.findIndex((text) => text.id === textStudyId);
+  const text = index >= 0 ? textStudies.value[index] : null;
+  const currentSession = session.value;
+  analyticsService.capture("session_text_expanded", {
+    session_id: currentSession?.id,
+    text_type: currentSession?.type,
+    // Rang dans l'ordre de la chaîne (pas dans l'ordre affiché, qui dépend du
+    // filtre et de la recherche) : ouvrir le 1er texte ou le 120e ne dit pas la
+    // même chose de l'effort fourni pour trouver une section libre.
+    rank: index >= 0 ? index + 1 : null,
+    has_available_sections:
+      text && currentSession ? !sessionService.isTextFullyReserved(text, currentSession) : null,
+    is_authenticated: currentUser.value != null,
+  });
+};
+
+/**
+ * Première frappe de l'invité dans le formulaire nom/email. C'est le meilleur
+ * prédicteur de la réservation effective : `reservation_failed` montre que la
+ * moitié des clics de confirmation repartent vers ce formulaire resté vide.
+ * `has_selection` dit s'il le remplit avant ou après avoir coché ses sections.
+ */
+const trackGuestFormFilled = (field: "name" | "email") => {
+  if (hasTrackedGuestForm) return;
+  hasTrackedGuestForm = true;
+  analyticsService.capture("guest_form_filled", {
+    session_id: session.value?.id,
+    field,
+    has_selection: selectedItems.value.size > 0,
+    source: "session_page",
+  });
+};
 
 const trackFirstSelection = () => {
   if (hasTrackedSelection) return;
@@ -596,7 +641,11 @@ watch(session, (s) => applySessionSeo(s));
               : t("detailSession.guestSubtitle")
           }}
         </p>
-        <GuestForm v-model:reservationForm="reservationForm" :email-required="guestEmailRequired" />
+        <GuestForm
+          v-model:reservationForm="reservationForm"
+          :email-required="guestEmailRequired"
+          @first-input="trackGuestFormFilled"
+        />
       </div>
 
       <!-- Barre de recherche -->
@@ -657,6 +706,7 @@ watch(session, (s) => applySessionSeo(s));
         @item-click="handleItemClick"
         @toggle-completion="toggleReservationCompletion"
         @toggle-select-all="handleToggleSelectAll"
+        @text-expanded="trackTextExpanded"
       />
 
       <!-- CTA : inviter le visiteur à créer sa propre session -->

--- a/src/views/ShareReading/detailSession/TextStudiesList.vue
+++ b/src/views/ShareReading/detailSession/TextStudiesList.vue
@@ -21,6 +21,9 @@ const emit = defineEmits<{
   (e: "item-click", textId: string, section?: number): void;
   (e: "toggle-completion", textId: string, section: number): void;
   (e: "toggle-select-all", textId: string): void;
+  // Dépliage d'un texte pour voir ses chapitres : passage obligé avant de
+  // cocher une section. La page parente en fait une étape de funnel.
+  (e: "text-expanded", textId: string): void;
 }>();
 
 const expandedTexts = ref<Set<string>>(new Set());
@@ -30,6 +33,7 @@ const toggleTextExpansion = (textId: string) => {
     expandedTexts.value.delete(textId);
   } else {
     expandedTexts.value.add(textId);
+    emit("text-expanded", textId);
   }
 };
 

--- a/src/views/TextReading/TextReadingPage.vue
+++ b/src/views/TextReading/TextReadingPage.vue
@@ -286,6 +286,24 @@ watch([canReserveNow, reservationUnit], ([canReserve, unit]) => {
   });
 });
 
+// Même signal que sur la page de chaîne : la première frappe dans le
+// formulaire invité, une seule fois par visite (voir trackGuestFormFilled dans
+// DetailSession.vue).
+let hasTrackedGuestForm = false;
+
+function trackGuestFormFilled(field: "name" | "email") {
+  if (hasTrackedGuestForm || !session.value) return;
+  hasTrackedGuestForm = true;
+  analyticsService.capture("guest_form_filled", {
+    session_id: session.value.id,
+    field,
+    // Toujours vrai ici : le formulaire ne s'affiche que sur une section libre
+    // déjà ouverte, il n'y a rien à cocher au préalable.
+    has_selection: true,
+    source: "reading_page",
+  });
+}
+
 async function reserve() {
   if (!session.value || reservationUnit.value === undefined) return;
   analyticsService.capture("reservation_confirm_clicked", {
@@ -667,6 +685,7 @@ watch(textId, loadContent);
               <GuestForm
                 v-model:reservation-form="reservationForm"
                 :email-required="guestEmailRequired"
+                @first-input="trackGuestFormFilled"
               />
             </div>
             <button @click="reserve" :disabled="isReserving" class="btn btn-primary text-sm">


### PR DESCRIPTION
## Pourquoi

Le funnel de réservation s'arrête aujourd'hui à « chaîne vue → 1re section cochée », avec 77 % de chute entre les deux et aucun moyen de savoir ce qui se passe au milieu. Deux événements manquaient.

## Ce que ça ajoute

**`session_text_expanded`** : sur un texte à plusieurs chapitres, il faut d'abord le déplier pour voir ses sections. C'est le passage obligé avant de cocher, et il était invisible (les clics ne ressortaient qu'en `$autocapture` sans libellé). Sans lui, impossible de distinguer « n'a jamais ouvert un texte » de « a ouvert et n'a rien coché ». Émis une fois par visite, comme `session_section_selected`, avec le rang du texte dans la chaîne : ouvrir le 1er ou le 120e ne dit pas la même chose de l'effort fourni pour trouver une section libre.

**`guest_form_filled`** : sur les 4 clics de confirmation mesurés à ce jour, 2 sont repartis en `reservation_failed` / `missing_name`, formulaire invité resté vide. Les deux personnes ont recliqué et réussi, donc le funnel n'en montre rien puisqu'il compte les personnes uniques. La première frappe dans le formulaire est le vrai prédicteur de la réservation, et `has_selection` dit si l'invité le remplit avant ou après avoir coché ses sections.

`GuestForm` n'émet qu'un signal (`first-input`) sans rien capturer : il sert aussi la page de gestion, où le propriétaire saisit un invité à la main, ce qui n'a rien à voir avec le funnel. Chaque page décide si le signal l'intéresse.

## Vérification

Testé sur les émulateurs avec une trace temporaire sur `analyticsService.capture` (retirée depuis) :

```
session_viewed        {"session_id":"2nLPT…","text_type":"Mishna","sections_total":513,…}
session_text_expanded {"rank":2,"has_available_sections":true,"is_authenticated":false,…}
guest_form_filled     {"field":"name","has_selection":false,"source":"session_page"}
session_section_selected + reservation_started  (inchangés)
```

Le second dépliage n'a pas réémis l'événement, la seconde frappe non plus. `npm run verify` passe (type-check, lint, 114 tests).

## Suite

Le funnel [Funnel réservation - page de chaîne](https://eu.posthog.com/project/233968/insights/NqCPt9em) est déjà créé côté PostHog et attend ces événements. L'étape « Texte déplié » y est marquée optionnelle : sur une chaîne de Tehilim les textes n'ont qu'une section, il n'y a rien à déplier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)