### PR TITLE
Fix bouton Lire : session= vide pour les sessions sans slug

### DIFF
--- a/src/__tests__/generateSlug.test.ts
+++ b/src/__tests__/generateSlug.test.ts
@@ -78,5 +78,11 @@ describe("UtilsService.generateSlug", () => {
     it("gère une chaîne sans diacritiques", () => {
       expect(UtilsService.generateSlug("Mishna Berachot")).toBe("mishna-berachot");
     });
+
+    // Les appelants doivent prévoir un repli (voir sessionService.generateUniqueSlug) :
+    // un slug vide stocké tel quel casse les liens ?session= de la page de session.
+    it("retourne une chaîne vide pour un nom entièrement en hébreu", () => {
+      expect(UtilsService.generateSlug("לעילוי נשמת פפי שלום")).toBe("");
+    });
   });
 });

--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -257,7 +257,10 @@ export class SessionService {
   }
 
   private async generateUniqueSlug(baseName: string, excludeSessionId?: string): Promise<string> {
-    const base = UtilsService.generateSlug(baseName);
+    // Un nom écrit entièrement en alphabet non latin (hébreu…) donne un slug
+    // vide une fois les caractères hors a-z0-9 supprimés : sans base de repli,
+    // la session serait stockée avec slug "" et les liens ?session= seraient vides.
+    const base = UtilsService.generateSlug(baseName) || "session";
     const existing = await firestoreService.getSessionBySlug(base);
     if (!existing || existing.id === excludeSessionId) return base;
 

--- a/src/views/ShareReading/detailSession/TextStudiesList.vue
+++ b/src/views/ShareReading/detailSession/TextStudiesList.vue
@@ -296,7 +296,7 @@ const handleCardClick = (text: TextStudy) => {
                   :to="{
                     name: 'text-reading',
                     params: { textId: text.id },
-                    query: { session: session.slug ?? session.id },
+                    query: { session: session.slug || session.id },
                   }"
                   class="btn btn-soft !px-3.5 !py-2 text-sm hover:!text-primary"
                   :title="t('detailSession.textList.readThisText')"
@@ -545,7 +545,7 @@ const handleCardClick = (text: TextStudy) => {
                     :to="{
                       name: 'text-reading-section',
                       params: { textId: text.id, section: chapter },
-                      query: { session: session.slug ?? session.id },
+                      query: { session: session.slug || session.id },
                     }"
                     class="w-8 h-8 flex items-center justify-center rounded-lg text-text-secondary hover:text-primary hover:bg-black/5 dark:hover:bg-white/10 transition-colors flex-shrink-0"
                     :title="t('detailSession.textList.readThisChapter')"


### PR DESCRIPTION
convertToSession normalise l'absence de slug en chaîne vide, que
l'opérateur ?? ne rattrape pas : les liens Lire de la page de session
pointaient vers /lire/:id?session= et le lecteur redirigeait alors vers
la bibliothèque générique, hors contexte de partage. Utiliser || comme
partout ailleurs pour retomber sur l'id de session.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018JJ8wrPTuypUtL14ZeWZcd