### PR TITLE
Bibliothèque : supprimer ses téléchargements, carte du jour allégée

### DIFF
--- a/src/components/DailyReadingCard.vue
+++ b/src/components/DailyReadingCard.vue
@@ -57,8 +57,11 @@ const allDone = computed(() => props.total > 0 && props.done >= props.total);
       </div>
     </template>
 
-    <p class="mt-4 text-sm font-medium text-primary flex items-center gap-1.5">
-      {{ total === 0 ? t("home.dashboard.readingSetupCta") : t("home.dashboard.readingCta") }}
+    <!-- Liste déjà composée : pas de « voir ma lecture » — la carte entière est
+         un lien (chevron compris), l'invitation à cliquer serait redondante.
+         Liste vide, en revanche, la suite ne va pas de soi : on l'annonce. -->
+    <p v-if="total === 0" class="mt-4 text-sm font-medium text-primary flex items-center gap-1.5">
+      {{ t("home.dashboard.readingSetupCta") }}
     </p>
   </RouterLink>
 </template>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -92,7 +92,6 @@ const en: LocaleMessages = {
       helloEvening: "Good evening",
       subtitle: "Here's where you stand today.",
       readingEmpty: "Build the list of texts you read every day.",
-      readingCta: "See my daily reading",
       readingSetupCta: "Pick my texts",
       resumeCta: "Resume my reading: {label}",
       resumeDismiss: "Stop suggesting this reading",
@@ -690,6 +689,13 @@ const en: LocaleMessages = {
     allDownloaded: "Everything is downloaded",
     download: "Download",
     delete: "Delete",
+    deleteAll: "Delete all",
+    deleteAllCorpus: "Delete this section",
+    deleteAllConfirm: "Delete the downloaded books ({count})? Texts stay readable online.",
+    deleteAllCorpusConfirm:
+      "Delete the downloaded books from {corpus} ({count})? Texts stay readable online.",
+    deleteAllDone: "Downloads deleted.",
+    deleteError: "Could not delete. Please try again.",
     error: "Download failed. Check your connection.",
   },
   offline: {

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -90,7 +90,6 @@ const fr = {
       helloEvening: "Bonsoir",
       subtitle: "Voici où vous en êtes aujourd'hui.",
       readingEmpty: "Composez la liste des textes que vous lisez chaque jour.",
-      readingCta: "Voir ma lecture quotidienne",
       readingSetupCta: "Choisir mes textes",
       resumeCta: "Reprendre ma lecture : {label}",
       resumeDismiss: "Ne plus proposer cette lecture",
@@ -696,6 +695,14 @@ const fr = {
     allDownloaded: "Tout est téléchargé",
     download: "Télécharger",
     delete: "Supprimer",
+    deleteAll: "Tout supprimer",
+    deleteAllCorpus: "Supprimer cette section",
+    deleteAllConfirm:
+      "Supprimer les livres téléchargés ({count}) ? Les textes restent lisibles en ligne.",
+    deleteAllCorpusConfirm:
+      "Supprimer les livres téléchargés de {corpus} ({count}) ? Les textes restent lisibles en ligne.",
+    deleteAllDone: "Téléchargements supprimés.",
+    deleteError: "Suppression impossible. Réessayez.",
     error: "Téléchargement impossible. Vérifiez votre connexion.",
   },
   offline: {

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -92,7 +92,6 @@ const he: LocaleMessages = {
       helloEvening: "ערב טוב",
       subtitle: "הנה איפה אתם עומדים היום.",
       readingEmpty: "הרכיבו את רשימת הטקסטים שאתם קוראים כל יום.",
-      readingCta: "לקריאה היומית שלי",
       readingSetupCta: "לבחור טקסטים",
       resumeCta: "להמשיך בקריאה: {label}",
       resumeDismiss: "להפסיק להציע קריאה זו",
@@ -678,6 +677,13 @@ const he: LocaleMessages = {
     allDownloaded: "הכול הורד",
     download: "הורדה",
     delete: "מחיקה",
+    deleteAll: "למחוק הכול",
+    deleteAllCorpus: "למחוק את החלק הזה",
+    deleteAllConfirm: "למחוק את הספרים שהורדו ({count})? הטקסטים יישארו זמינים לקריאה באינטרנט.",
+    deleteAllCorpusConfirm:
+      "למחוק את הספרים שהורדו מתוך {corpus} ({count})? הטקסטים יישארו זמינים לקריאה באינטרנט.",
+    deleteAllDone: "ההורדות נמחקו.",
+    deleteError: "המחיקה נכשלה. נסו שוב.",
     error: "ההורדה נכשלה. בדקו את החיבור.",
   },
   offline: {

--- a/src/services/offlineLibraryService.ts
+++ b/src/services/offlineLibraryService.ts
@@ -104,6 +104,30 @@ export async function downloadBook(book: OfflineBook): Promise<void> {
 
 export async function removeBook(book: OfflineBook): Promise<void> {
   await removeFile(book.path);
+  await removeOrphanTalmudChapters();
+}
+
+/**
+ * Supprime les copies locales d'un lot de livres (toute la bibliothèque ou un
+ * seul corpus). Les textes restent lisibles en ligne : seul l'espace disque
+ * est libéré.
+ */
+export async function removeBooks(books: OfflineBook[]): Promise<void> {
+  for (const book of books) {
+    await removeFile(book.path);
+  }
+  await removeOrphanTalmudChapters();
+}
+
+/**
+ * Le découpage en chapitres du Talmud n'est qu'une dépendance du lecteur,
+ * téléchargée avec la première guemara. Sans guemara téléchargée il n'a plus
+ * de raison d'occuper de la place (ni d'apparaître dans l'espace utilisé).
+ */
+async function removeOrphanTalmudChapters(): Promise<void> {
+  if (!isDownloaded(TALMUD_CHAPTERS_PATH)) return;
+  const hasTalmud = offlineBooks.some((b) => b.corpus === "Talmud Bavli" && isDownloaded(b.path));
+  if (!hasTalmud) await removeFile(TALMUD_CHAPTERS_PATH);
 }
 
 /**

--- a/src/views/StudyPage.vue
+++ b/src/views/StudyPage.vue
@@ -16,6 +16,7 @@ import {
   isBookDownloaded,
   offlineBooks,
   removeBook,
+  removeBooks,
   totalDownloadedSize,
   type OfflineBook,
 } from "../services/offlineLibraryService";
@@ -283,6 +284,40 @@ async function downloadAllInTab() {
   });
 }
 
+// Libérer de la place : symétrique de « Tout télécharger », donc au même
+// endroit et avec la même portée — toute la bibliothèque depuis l'accueil, le
+// corpus courant depuis sa page.
+const tabDownloadedBooks = computed(() => tabBooks.value.filter((b) => isBookDownloaded(b)));
+
+const removingAll = ref(false);
+
+async function removeAllInTab() {
+  if (removingAll.value) return;
+  const books = tabDownloadedBooks.value;
+  if (books.length === 0) return;
+  const corpus = currentCorpus.value;
+  const confirmed = window.confirm(
+    corpus
+      ? t("downloads.deleteAllCorpusConfirm", { count: books.length, corpus: t(corpus.labelKey) })
+      : t("downloads.deleteAllConfirm", { count: books.length }),
+  );
+  if (!confirmed) return;
+  removingAll.value = true;
+  try {
+    await removeBooks(books);
+    analyticsService.capture("offline_download_deleted", {
+      scope: "all",
+      tab: corpus?.typeKey ?? "Tout",
+      books_count: books.length,
+    });
+    toast.success(t("downloads.deleteAllDone"));
+  } catch {
+    toast.error(t("downloads.deleteError"));
+  } finally {
+    removingAll.value = false;
+  }
+}
+
 function formatSize(bytes: number): string {
   if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} Mo`;
   return `${Math.max(1, Math.round(bytes / 1024))} Ko`;
@@ -426,6 +461,18 @@ onUnmounted(() => {
         <AppIcon name="circle-check" :size="14" />
         {{ t("downloads.allDownloaded") }}
       </p>
+      <!-- Faire de la place : proposé dès qu'il y a quelque chose à supprimer
+           dans la portée courante (bibliothèque entière ou corpus affiché). -->
+      <button
+        v-if="tabDownloadedBooks.length > 0"
+        class="btn btn-danger"
+        :disabled="removingAll"
+        @click="removeAllInTab()"
+      >
+        <AppIcon v-if="removingAll" name="spinner" :size="14" class="animate-spin" />
+        <AppIcon v-else name="trash" :size="14" />
+        {{ currentCorpus ? t("downloads.deleteAllCorpus") : t("downloads.deleteAll") }}
+      </button>
       <p v-if="totalDownloadedSize > 0" class="text-sm text-text-secondary">
         {{ t("downloads.total", { size: formatSize(totalDownloadedSize) }) }}
       </p>


### PR DESCRIPTION
## Carte « lecture quotidienne »

La carte entière est un lien, chevron compris : le « Voir ma lecture quotidienne » en bas ne disait rien de plus. Il disparaît (clé `home.dashboard.readingCta` retirée des trois locales).

La liste vide garde son « Choisir mes textes » : là, l'étape suivante n'est pas devinable.

## Suppression des téléchargements (app native)

La bibliothèque savait tout télécharger, mais pas faire le chemin inverse. Un bouton de suppression rejoint « Tout télécharger », au même endroit et avec la même portée :

- depuis l'accueil de la bibliothèque : **« Tout supprimer »** → toute la bibliothèque ;
- depuis une page de corpus : **« Supprimer cette section »** → ce corpus seul.

Le bouton n'apparaît que s'il y a quelque chose à supprimer dans la portée courante, demande confirmation (nombre de livres concernés + rappel que les textes restent lisibles en ligne), affiche un spinner pendant l'opération et un toast à la fin. L'espace utilisé se met à jour tout seul.

Au passage : le découpage en chapitres du Talmud, téléchargé en dépendance de la première guemara, n'était jamais supprimé — il occupait de la place que rien ne permettait de libérer. Il est maintenant nettoyé dès qu'il ne reste plus aucune guemara téléchargée, y compris via la suppression d'un livre isolé.

## Fichiers

- `src/components/DailyReadingCard.vue` — CTA retiré (conservé pour la liste vide)
- `src/services/offlineLibraryService.ts` — `removeBooks()` + nettoyage du fichier de chapitres orphelin
- `src/views/StudyPage.vue` — bouton, confirmation, analytics `offline_download_deleted` (scope `all`)
- `src/locales/{fr,en,he}.ts` — nouvelles clés `downloads.deleteAll*`, `readingCta` supprimée

## Vérifications

`npm run verify` : type-check, lint et 141 tests passent.

À noter : après une suppression complète, rouvrir « Ma lecture du jour » re-télécharge en arrière-plan les textes de la liste quotidienne. C'est le comportement existant, inchangé ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148nNmmoEP5LFneLX7JSNjT

---
_Generated by [Claude Code](https://claude.ai/code/session_0148nNmmoEP5LFneLX7JSNjT)_